### PR TITLE
Fix JIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Nx.default_backend({EMLX.Backend, device: :gpu})
 If desireable, you can also set the default compiler:
 
 ```elixir
-Nx.Defn.default_options(compiler: EMLX.Compiler)
+Nx.Defn.default_options(compiler: EMLX)
 ```
 
 ### MLX binaries

--- a/lib/emlx.ex
+++ b/lib/emlx.ex
@@ -336,7 +336,7 @@ defmodule EMLX do
     [result] = fun.(args_list)
 
     Nx.Defn.Composite.traverse(result, fn
-      %Nx.Tensor{data: %EMLX.Backend{ref: {_device, ref}}} = node ->
+      %Nx.Tensor{data: %EMLX.Backend{ref: ref}} = node ->
         :ok = eval(ref)
         node
 


### PR DESCRIPTION
Thanks for the great work!

Seems like `eval` requires a tuple of device and ref instead of just ref.

Also readme referred to `EMLX.Compiler` module which does not exist (yet?).