### PR TITLE
remove raising on tie_break :high

### DIFF
--- a/lib/emlx/backend.ex
+++ b/lib/emlx/backend.ex
@@ -535,10 +535,6 @@ defmodule EMLX.Backend do
       axis = opts[:axis]
       keep_axis = opts[:keep_axis] == true
 
-      if opts[:tie_break] == :high do
-        raise "Nx.Backend.#{unquote(op)}/3 with tie_break: :high is not supported in EMLX"
-      end
-
       t_mx = from_nx(tensor)
 
       result =


### PR DESCRIPTION
Removes raising on tie_break: :high option in argmin and argmax to allow to run models that use this option, closes #78.
