### PR TITLE
Fix int32 overflow in elem_count for tensors with >2.1B elements

### DIFF
--- a/.github/workflows/emlx.yml
+++ b/.github/workflows/emlx.yml
@@ -72,7 +72,7 @@ jobs:
           mix test --warnings-as-errors
 
   macos:
-    name: macOS (${{ matrix.job.elixir }}, ${{ matrix.job.otp }})
+    name: macOS ${{ matrix.job.gpu && 'gpu' || 'cpu' }} (${{ matrix.job.elixir }}, ${{ matrix.job.otp }})
     runs-on: macos-26
     strategy:
       fail-fast: false

--- a/emlx/c_src/emlx_nif.cpp
+++ b/emlx/c_src/emlx_nif.cpp
@@ -218,7 +218,7 @@ NIF(to_blob) {
 }
 
 uint64_t elem_count(std::vector<int> shape) {
-  return std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<>{});
+  return std::accumulate(shape.begin(), shape.end(), uint64_t{1}, std::multiplies<uint64_t>{});
 }
 
 NIF(from_blob) {

--- a/emlx/test/emlx_test.exs
+++ b/emlx/test/emlx_test.exs
@@ -173,6 +173,7 @@ defmodule EMLXTest do
 
   # Regression: elem_count overflowed int32 for shapes whose element count
   # exceeds INT32_MAX, causing "Binary size is too small" on valid binaries.
+  @tag :large_memory
   test "from_binary accepts shape whose element count exceeds INT32_MAX" do
     # Reshape on BinaryBackend first — Nx.from_binary creates a flat 1D tensor
     # whose single dimension would also exceed INT32_MAX.

--- a/emlx/test/emlx_test.exs
+++ b/emlx/test/emlx_test.exs
@@ -170,4 +170,23 @@ defmodule EMLXTest do
       end
     end
   end
+
+  describe "large tensors (element count > INT32_MAX)" do
+    # Regression: elem_count overflowed int32 for shapes whose element count
+    # exceeds INT32_MAX, causing "Binary size is too small" on valid binaries.
+    @tag :large_tensor
+    test "from_binary accepts shape whose element count exceeds INT32_MAX" do
+      # Reshape on BinaryBackend first — Nx.from_binary creates a flat 1D tensor
+      # whose single dimension would also exceed INT32_MAX.
+      binary = :binary.copy(<<7>>, 2_147_483_648)
+
+      t =
+        Nx.from_binary(binary, :u8, backend: Nx.BinaryBackend)
+        |> Nx.reshape({2, 1_073_741_824})
+        |> Nx.backend_transfer(EMLX.Backend)
+
+      assert Nx.shape(t) == {2, 1_073_741_824}
+      assert Nx.to_number(t[0][0]) == 7
+    end
+  end
 end

--- a/emlx/test/emlx_test.exs
+++ b/emlx/test/emlx_test.exs
@@ -171,22 +171,19 @@ defmodule EMLXTest do
     end
   end
 
-  describe "large tensors (element count > INT32_MAX)" do
-    # Regression: elem_count overflowed int32 for shapes whose element count
-    # exceeds INT32_MAX, causing "Binary size is too small" on valid binaries.
-    @tag :large_tensor
-    test "from_binary accepts shape whose element count exceeds INT32_MAX" do
-      # Reshape on BinaryBackend first — Nx.from_binary creates a flat 1D tensor
-      # whose single dimension would also exceed INT32_MAX.
-      binary = :binary.copy(<<7>>, 2_147_483_648)
+  # Regression: elem_count overflowed int32 for shapes whose element count
+  # exceeds INT32_MAX, causing "Binary size is too small" on valid binaries.
+  test "from_binary accepts shape whose element count exceeds INT32_MAX" do
+    # Reshape on BinaryBackend first — Nx.from_binary creates a flat 1D tensor
+    # whose single dimension would also exceed INT32_MAX.
+    int_32_max = 2 ** 31
+    binary = String.duplicate(<<7>>, int_32_max)
+    shape = {2, div(int_32_max, 2)}
 
-      t =
-        Nx.from_binary(binary, :u8, backend: Nx.BinaryBackend)
-        |> Nx.reshape({2, 1_073_741_824})
-        |> Nx.backend_transfer(EMLX.Backend)
+    out = Nx.template(shape, :u8)
+    t = EMLX.Backend.from_binary(out, binary, backend: EMLX.Backend)
 
-      assert Nx.shape(t) == {2, 1_073_741_824}
-      assert Nx.to_number(t[0][0]) == 7
-    end
+    assert Nx.shape(t) == shape
+    assert_equal(Nx.all(Nx.equal(t, 7)), 1)
   end
 end

--- a/emlx/test/test_helper.exs
+++ b/emlx/test/test_helper.exs
@@ -55,4 +55,4 @@ gpu_exclude =
     {:error, _} -> [:metal]
   end
 
-ExUnit.start(exclude: distributed_exclude ++ gpu_exclude ++ large_memory_exclude)
+ExUnit.start(exclude: distributed_exclude ++ gpu_exclude)

--- a/emlx/test/test_helper.exs
+++ b/emlx/test/test_helper.exs
@@ -51,8 +51,8 @@ distributed_exclude =
 
 gpu_exclude =
   case EMLX.NIF.command_queue_new(:gpu) do
-    {:ok, _} -> []
+    {:ok, _} -> [:large_memory]
     {:error, _} -> [:metal]
   end
 
-ExUnit.start(exclude: distributed_exclude ++ gpu_exclude)
+ExUnit.start(exclude: distributed_exclude ++ gpu_exclude ++ large_memory_exclude)


### PR DESCRIPTION
## Problem

`elem_count` uses `std::accumulate` with an `int` initial value:

```cpp
uint64_t elem_count(std::vector<int> shape) {
  return std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<>{});
}
```

When the initial accumulator value is `int`, all intermediate multiplications are performed in 32-bit signed arithmetic. For shapes whose element-count product exceeds `INT32_MAX` (~2.1B), the product overflows to a negative `int`, which is then cast to a large `uint64_t` value. The binary-size guard in `from_blob` then always fires:

```
** (RuntimeError) Binary size is too small for the requested shape
```

### Reproduction

`google/gemma-4-2b-it` (and larger Gemma-4 variants) include a weight called `embed_tokens_per_layer` with shape `{262144, 8960}`:

```
262144 × 8960 = 2,348,810,240  >  INT32_MAX (2,147,483,647)
```

This causes `elem_count({262144, 8960})` to return `18,446,744,071,762,394,560` instead of `2,348,810,240`, making it impossible to load the model via `EMLX.Backend`.

## Fix

Seed the accumulator with `uint64_t{1}` and use `std::multiplies<uint64_t>` so every partial product stays in 64-bit arithmetic:

```cpp
uint64_t elem_count(std::vector<int> shape) {
  return std::accumulate(shape.begin(), shape.end(), uint64_t{1}, std::multiplies<uint64_t>{});
}
```

## Context

Discovered while implementing Gemma-4 support in Bumblebee: [elixir-nx/bumblebee#460](https://github.com/elixir-nx/bumblebee/pull/460).

🤖 Generated with [Claude Code](https://claude.com/claude-code)