### PR TITLE
feat: add native dense Qwen3 layer primitives

### DIFF
--- a/emlx/c_src/emlx_fast.cpp
+++ b/emlx/c_src/emlx_fast.cpp
@@ -640,3 +640,796 @@ NIF(kv_cache_sdpa_update) {
   CATCH()
 }
 ASYNC_NIF(kv_cache_sdpa_update)
+
+static ERL_NIF_TERM qwen3_error(ErlNifEnv *env, const std::string &message) {
+  return nx::nif::error(env, message.c_str());
+}
+
+static bool qwen3_check_rank(
+    const mlx::core::array &tensor,
+    int expected,
+    const char *name,
+    std::string &error) {
+  if (tensor.ndim() != expected) {
+    std::ostringstream msg;
+    msg << name << " expects rank " << expected << ", got rank " << tensor.ndim();
+    error = msg.str();
+    return false;
+  }
+
+  return true;
+}
+
+static bool qwen3_check_positive(int value, const char *name, std::string &error) {
+  if (value <= 0) {
+    std::ostringstream msg;
+    msg << name << " must be positive";
+    error = msg.str();
+    return false;
+  }
+
+  return true;
+}
+
+static bool qwen3_check_non_negative(int value, const char *name, std::string &error) {
+  if (value < 0) {
+    std::ostringstream msg;
+    msg << name << " must be non-negative";
+    error = msg.str();
+    return false;
+  }
+
+  return true;
+}
+
+static bool qwen3_check_dim(
+    const mlx::core::array &tensor,
+    int axis,
+    int expected,
+    const char *name,
+    const char *dim_name,
+    std::string &error) {
+  if (tensor.shape(axis) != expected) {
+    std::ostringstream msg;
+    msg << name << " " << dim_name << " must be " << expected
+        << ", got " << tensor.shape(axis);
+    error = msg.str();
+    return false;
+  }
+
+  return true;
+}
+
+static bool qwen3_check_rank4_positive(
+    const mlx::core::array &tensor,
+    const char *name,
+    std::string &error) {
+  if (!qwen3_check_rank(tensor, 4, name, error)) {
+    return false;
+  }
+
+  for (int axis = 0; axis < 4; ++axis) {
+    if (tensor.shape(axis) <= 0) {
+      std::ostringstream msg;
+      msg << name << " dimensions must be positive";
+      error = msg.str();
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool qwen3_check_rank3_positive(
+    const mlx::core::array &tensor,
+    const char *name,
+    std::string &error) {
+  if (!qwen3_check_rank(tensor, 3, name, error)) {
+    return false;
+  }
+
+  for (int axis = 0; axis < 3; ++axis) {
+    if (tensor.shape(axis) <= 0) {
+      std::ostringstream msg;
+      msg << name << " dimensions must be positive";
+      error = msg.str();
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool qwen3_check_rank2_positive(
+    const mlx::core::array &tensor,
+    const char *name,
+    std::string &error) {
+  if (!qwen3_check_rank(tensor, 2, name, error)) {
+    return false;
+  }
+
+  for (int axis = 0; axis < 2; ++axis) {
+    if (tensor.shape(axis) <= 0) {
+      std::ostringstream msg;
+      msg << name << " dimensions must be positive";
+      error = msg.str();
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static bool qwen3_check_rank1_dim(
+    const mlx::core::array &tensor,
+    int expected,
+    const char *name,
+    std::string &error) {
+  if (!qwen3_check_rank(tensor, 1, name, error)) {
+    return false;
+  }
+
+  return qwen3_check_dim(tensor, 0, expected, name, "size", error);
+}
+
+static bool qwen3_validate_projection_width(
+    const mlx::core::array &projection,
+    int input_width,
+    int head_dim,
+    const char *name,
+    std::string &error) {
+  if (!qwen3_check_rank2_positive(projection, name, error)) {
+    return false;
+  }
+  if (!qwen3_check_dim(projection, 0, input_width, name, "input width", error)) {
+    return false;
+  }
+  if ((projection.shape(1) % head_dim) != 0) {
+    std::ostringstream msg;
+    msg << name << " output width must be divisible by head_dim";
+    error = msg.str();
+    return false;
+  }
+
+  return true;
+}
+
+static bool qwen3_validate_kv_cache_bn(
+    const mlx::core::array &k_cache,
+    const mlx::core::array &v_cache,
+    int batch,
+    int num_kv_heads,
+    int offset,
+    int token_count,
+    int head_dim,
+    std::string &error) {
+  if (!qwen3_check_rank4_positive(k_cache, "k_cache", error) ||
+      !qwen3_check_rank4_positive(v_cache, "v_cache", error)) {
+    return false;
+  }
+
+  if (!qwen3_check_dim(k_cache, 0, batch, "k_cache", "batch", error) ||
+      !qwen3_check_dim(v_cache, 0, batch, "v_cache", "batch", error) ||
+      !qwen3_check_dim(k_cache, 1, num_kv_heads, "k_cache", "heads", error) ||
+      !qwen3_check_dim(v_cache, 1, num_kv_heads, "v_cache", "heads", error) ||
+      !qwen3_check_dim(k_cache, 3, head_dim, "k_cache", "head_dim", error) ||
+      !qwen3_check_dim(v_cache, 3, head_dim, "v_cache", "head_dim", error)) {
+    return false;
+  }
+
+  if (v_cache.shape(2) != k_cache.shape(2)) {
+    error = "k_cache and v_cache capacity must match";
+    return false;
+  }
+
+  int64_t required_len = static_cast<int64_t>(offset) + static_cast<int64_t>(token_count);
+  int capacity = k_cache.shape(2);
+
+  if (required_len > capacity) {
+    std::ostringstream msg;
+    msg << "KV cache capacity " << capacity
+        << " is smaller than required length " << required_len;
+    error = msg.str();
+    return false;
+  }
+
+  return true;
+}
+
+static bool qwen3_validate_qkv_cache_attention(
+    const mlx::core::array &q,
+    const mlx::core::array &new_k,
+    const mlx::core::array &new_v,
+    const mlx::core::array &k_cache,
+    const mlx::core::array &v_cache,
+    int offset,
+    int head_dim,
+    std::string &error) {
+  if (!qwen3_check_rank4_positive(q, "q", error) ||
+      !qwen3_check_rank4_positive(new_k, "new_k", error) ||
+      !qwen3_check_rank4_positive(new_v, "new_v", error) ||
+      !qwen3_check_non_negative(offset, "offset", error) ||
+      !qwen3_check_positive(head_dim, "head_dim", error)) {
+    return false;
+  }
+
+  int B = q.shape(0);
+  int T_new = q.shape(1);
+  int N_q = q.shape(2);
+  int D = q.shape(3);
+  int N_kv = new_k.shape(2);
+
+  if (D != head_dim) {
+    error = "q last dimension must match head_dim";
+    return false;
+  }
+  if ((N_q % N_kv) != 0) {
+    error = "query heads must be divisible by key/value heads";
+    return false;
+  }
+  if (!qwen3_check_dim(new_k, 0, B, "new_k", "batch", error) ||
+      !qwen3_check_dim(new_v, 0, B, "new_v", "batch", error) ||
+      !qwen3_check_dim(new_k, 1, T_new, "new_k", "sequence length", error) ||
+      !qwen3_check_dim(new_v, 1, T_new, "new_v", "sequence length", error) ||
+      !qwen3_check_dim(new_v, 2, N_kv, "new_v", "heads", error) ||
+      !qwen3_check_dim(new_k, 3, D, "new_k", "head_dim", error) ||
+      !qwen3_check_dim(new_v, 3, D, "new_v", "head_dim", error)) {
+    return false;
+  }
+
+  return qwen3_validate_kv_cache_bn(k_cache, v_cache, B, N_kv, offset, T_new, D, error);
+}
+
+// qwen3_kv_cache_attention — Qwen3-specific fused RoPE + KV update + SDPA.
+//
+// Inputs:
+//   q        — {B, T_new, N_q,  D}  Q projection after Q norm
+//   new_k    — {B, T_new, N_kv, D}  K projection after K norm
+//   new_v    — {B, T_new, N_kv, D}  V projection
+//   k_cache  — {B, N_kv, T_max, D}  pre-allocated key buffer
+//   v_cache  — {B, N_kv, T_max, D}  pre-allocated value buffer
+//   offset   — int                  tokens already in cache
+//   scale    — float                1/sqrt(head_dim)
+//   head_dim — int                  RoPE dimensions
+//   theta    — float                RoPE base
+//   device   — atom
+//
+// Returns {attn_out, k_upd, v_upd}:
+//   attn_out — {B, T_new, N_q * D}  projection-ready BTH layout
+//   k_upd    — {B, N_kv, T_max, D}
+//   v_upd    — {B, N_kv, T_max, D}
+NIF(qwen3_kv_cache_attention) {
+  TENSOR_PARAM(0, q);
+  TENSOR_PARAM(1, new_k);
+  TENSOR_PARAM(2, new_v);
+  TENSOR_PARAM(3, k_cache);
+  TENSOR_PARAM(4, v_cache);
+  PARAM(5, int, offset);
+  PARAM(6, double, scale);
+  PARAM(7, int, head_dim);
+  PARAM(8, double, theta);
+  DEVICE_PARAM(9, device);
+
+  try {
+    std::string error;
+    if (!qwen3_validate_qkv_cache_attention(
+            *q, *new_k, *new_v, *k_cache, *v_cache, offset, head_dim, error)) {
+      return qwen3_error(env, error);
+    }
+
+    int B       = q->shape(0);
+    int T_new   = q->shape(1);
+    int N_q     = q->shape(2);
+    int D       = q->shape(3);
+    int N_kv    = new_k->shape(2);
+    int valid_len = offset + T_new;
+
+    auto q_bn = mlx::core::transpose(*q, {0, 2, 1, 3}, device);
+    auto k_bn = mlx::core::transpose(*new_k, {0, 2, 1, 3}, device);
+    auto v_bn = mlx::core::transpose(*new_v, {0, 2, 1, 3}, device);
+
+    auto q_rope = mlx::core::fast::rope(
+        q_bn, head_dim, false, (float)theta, 1.0f, offset, std::nullopt, device);
+    auto k_rope = mlx::core::fast::rope(
+        k_bn, head_dim, false, (float)theta, 1.0f, offset, std::nullopt, device);
+
+    auto k_cache_owned = std::move(*k_cache);
+    auto v_cache_owned = std::move(*v_cache);
+
+    auto k_upd = mlx::core::slice_update(
+        k_cache_owned, k_rope,
+        to_shape({0, 0, offset, 0}),
+        to_shape({B, N_kv, valid_len, D}),
+        device);
+    auto v_upd = mlx::core::slice_update(
+        v_cache_owned, v_bn,
+        to_shape({0, 0, offset, 0}),
+        to_shape({B, N_kv, valid_len, D}),
+        device);
+
+    auto k_valid = mlx::core::slice(
+        k_upd, to_shape({0, 0, 0, 0}), to_shape({B, N_kv, valid_len, D}), device);
+    auto v_valid = mlx::core::slice(
+        v_upd, to_shape({0, 0, 0, 0}), to_shape({B, N_kv, valid_len, D}), device);
+
+    auto build_prefill_mask = [&]() -> mlx::core::array {
+      auto mask_dtype = q->dtype();
+      auto zero_val   = mlx::core::zeros({}, mask_dtype, device);
+      auto neginf_val = mlx::core::full({}, -std::numeric_limits<float>::infinity(), mask_dtype, device);
+      int kv_offset = valid_len - T_new;
+      auto row = mlx::core::reshape(
+          mlx::core::arange(T_new,     mlx::core::int32, device), {1, 1, T_new, 1},     device);
+      auto col = mlx::core::reshape(
+          mlx::core::arange(valid_len, mlx::core::int32, device), {1, 1, 1, valid_len}, device);
+      auto causal_bool = mlx::core::less_equal(
+          col, mlx::core::add(row, mlx::core::array(kv_offset, mlx::core::int32), device), device);
+      return mlx::core::where(causal_bool, zero_val, neginf_val, device);
+    };
+
+    auto attn_out_bn = (T_new == 1)
+      ? mlx::core::fast::scaled_dot_product_attention(
+            q_rope, k_valid, v_valid, (float)scale, "", std::nullopt, std::nullopt, device)
+      : mlx::core::fast::scaled_dot_product_attention(
+            q_rope, k_valid, v_valid, (float)scale, "array", build_prefill_mask(), std::nullopt, device);
+    auto attn_out_bthd = mlx::core::transpose(attn_out_bn, {0, 2, 1, 3}, device);
+    auto attn_out = mlx::core::reshape(attn_out_bthd, {B, T_new, N_q * D}, device);
+
+    ERL_NIF_TERM result_tuple[3];
+    result_tuple[0] = create_tensor_resource(env, attn_out);
+    result_tuple[1] = create_tensor_resource(env, k_upd);
+    result_tuple[2] = create_tensor_resource(env, v_upd);
+
+    return nx::nif::ok(env, enif_make_tuple3(env, result_tuple[0], result_tuple[1], result_tuple[2]));
+  }
+  CATCH()
+}
+ASYNC_NIF(qwen3_kv_cache_attention)
+
+static mlx::core::array qwen3_linear_in_out(
+    const mlx::core::array &x,
+    const mlx::core::array &weight,
+    const mlx::core::Device &device) {
+  if (x.ndim() == 3 && x.shape(1) == 1) {
+    auto x_2d = mlx::core::reshape(x, {x.shape(0), x.shape(2)}, device);
+    auto out = mlx::core::matmul(x_2d, weight, device);
+    return mlx::core::reshape(out, {x.shape(0), 1, weight.shape(1)}, device);
+  }
+
+  return mlx::core::matmul(x, weight, device);
+}
+
+// qwen3_mlp — dense Qwen3 MLP block: RMSNorm + gate/up + SwiGLU + down + residual.
+//
+// Inputs:
+//   hidden    — {B, T, H}
+//   norm      — {H}
+//   gate_proj — {H, I}
+//   up_proj   — {H, I}
+//   down_proj — {I, H}
+//   eps       — RMSNorm epsilon
+//
+// Returns hidden + out {B, T, H}.
+NIF(qwen3_mlp) {
+  TENSOR_PARAM(0, hidden);
+  TENSOR_PARAM(1, norm);
+  TENSOR_PARAM(2, gate_proj);
+  TENSOR_PARAM(3, up_proj);
+  TENSOR_PARAM(4, down_proj);
+  PARAM(5, double, eps);
+  DEVICE_PARAM(6, device);
+
+  try {
+    std::string error;
+    if (!qwen3_check_rank3_positive(*hidden, "hidden", error)) {
+      return qwen3_error(env, error);
+    }
+
+    int H = hidden->shape(2);
+    if (!qwen3_check_rank1_dim(*norm, H, "norm", error) ||
+        !qwen3_check_rank2_positive(*gate_proj, "gate_proj", error) ||
+        !qwen3_check_rank2_positive(*up_proj, "up_proj", error) ||
+        !qwen3_check_rank2_positive(*down_proj, "down_proj", error) ||
+        !qwen3_check_dim(*gate_proj, 0, H, "gate_proj", "input width", error) ||
+        !qwen3_check_dim(*up_proj, 0, H, "up_proj", "input width", error) ||
+        !qwen3_check_dim(*up_proj, 1, gate_proj->shape(1), "up_proj", "output width", error) ||
+        !qwen3_check_dim(*down_proj, 0, gate_proj->shape(1), "down_proj", "input width", error) ||
+        !qwen3_check_dim(*down_proj, 1, H, "down_proj", "output width", error)) {
+      return qwen3_error(env, error);
+    }
+
+    auto xn = mlx::core::fast::rms_norm(*hidden, *norm, (float)eps, device);
+    auto gate = qwen3_linear_in_out(xn, *gate_proj, device);
+    auto up = qwen3_linear_in_out(xn, *up_proj, device);
+    auto mlp = mlx::core::multiply(
+        mlx::core::multiply(gate, mlx::core::sigmoid(gate, device), device),
+        up,
+        device);
+    auto out = qwen3_linear_in_out(mlp, *down_proj, device);
+    auto residual = mlx::core::add(*hidden, out, device);
+
+    TENSOR(residual);
+  }
+  CATCH()
+}
+ASYNC_NIF(qwen3_mlp)
+
+// qwen3_layer — dense Qwen3 transformer layer:
+// attention input RMSNorm + dense attention block + post-attention RMSNorm
+// + dense MLP + residual add.
+//
+// Inputs:
+//   hidden    — {B, T_new, H}
+//   norm1     — {H}
+//   q_proj    — {H, N_q * D}
+//   k_proj    — {H, N_kv * D}
+//   v_proj    — {H, N_kv * D}
+//   o_proj    — {N_q * D, H}
+//   q_norm    — {D}
+//   k_norm    — {D}
+//   k_cache   — {B, N_kv, T_max, D}
+//   v_cache   — {B, N_kv, T_max, D}
+//   norm2     — {H}
+//   gate_proj — {H, I}
+//   up_proj   — {H, I}
+//   down_proj — {I, H}
+//   offset    — int
+//   scale     — float
+//   head_dim  — int
+//   theta     — float
+//   eps       — RMSNorm epsilon
+//
+// Returns {hidden_out, k_upd, v_upd}.
+NIF(qwen3_layer) {
+  TENSOR_PARAM(0, hidden);
+  TENSOR_PARAM(1, norm1);
+  TENSOR_PARAM(2, q_proj);
+  TENSOR_PARAM(3, k_proj);
+  TENSOR_PARAM(4, v_proj);
+  TENSOR_PARAM(5, o_proj);
+  TENSOR_PARAM(6, q_norm);
+  TENSOR_PARAM(7, k_norm);
+  TENSOR_PARAM(8, k_cache);
+  TENSOR_PARAM(9, v_cache);
+  TENSOR_PARAM(10, norm2);
+  TENSOR_PARAM(11, gate_proj);
+  TENSOR_PARAM(12, up_proj);
+  TENSOR_PARAM(13, down_proj);
+  PARAM(14, int, offset);
+  PARAM(15, double, scale);
+  PARAM(16, int, head_dim);
+  PARAM(17, double, theta);
+  PARAM(18, double, eps);
+  DEVICE_PARAM(19, device);
+
+  try {
+    std::string error;
+    if (!qwen3_check_rank3_positive(*hidden, "hidden", error) ||
+        !qwen3_check_non_negative(offset, "offset", error) ||
+        !qwen3_check_positive(head_dim, "head_dim", error)) {
+      return qwen3_error(env, error);
+    }
+
+    int B       = hidden->shape(0);
+    int T_new   = hidden->shape(1);
+    int H       = hidden->shape(2);
+    int D       = head_dim;
+    if (!qwen3_check_rank1_dim(*norm1, H, "norm1", error) ||
+        !qwen3_check_rank1_dim(*norm2, H, "norm2", error) ||
+        !qwen3_validate_projection_width(*q_proj, H, D, "q_proj", error) ||
+        !qwen3_validate_projection_width(*k_proj, H, D, "k_proj", error) ||
+        !qwen3_validate_projection_width(*v_proj, H, D, "v_proj", error) ||
+        !qwen3_check_dim(*v_proj, 1, k_proj->shape(1), "v_proj", "output width", error) ||
+        !qwen3_check_rank1_dim(*q_norm, D, "q_norm", error) ||
+        !qwen3_check_rank1_dim(*k_norm, D, "k_norm", error)) {
+      return qwen3_error(env, error);
+    }
+
+    int N_q     = q_proj->shape(1) / D;
+    int N_kv    = k_proj->shape(1) / D;
+    int attn_width = N_q * D;
+
+    if ((N_q % N_kv) != 0) {
+      return qwen3_error(env, "query heads must be divisible by key/value heads");
+    }
+    if (!qwen3_check_rank2_positive(*o_proj, "o_proj", error) ||
+        !qwen3_check_dim(*o_proj, 0, attn_width, "o_proj", "input width", error) ||
+        !qwen3_check_dim(*o_proj, 1, H, "o_proj", "output width", error) ||
+        !qwen3_validate_kv_cache_bn(*k_cache, *v_cache, B, N_kv, offset, T_new, D, error) ||
+        !qwen3_check_rank2_positive(*gate_proj, "gate_proj", error) ||
+        !qwen3_check_rank2_positive(*up_proj, "up_proj", error) ||
+        !qwen3_check_rank2_positive(*down_proj, "down_proj", error) ||
+        !qwen3_check_dim(*gate_proj, 0, H, "gate_proj", "input width", error) ||
+        !qwen3_check_dim(*up_proj, 0, H, "up_proj", "input width", error) ||
+        !qwen3_check_dim(*up_proj, 1, gate_proj->shape(1), "up_proj", "output width", error) ||
+        !qwen3_check_dim(*down_proj, 0, gate_proj->shape(1), "down_proj", "input width", error) ||
+        !qwen3_check_dim(*down_proj, 1, H, "down_proj", "output width", error)) {
+      return qwen3_error(env, error);
+    }
+    int valid_len = offset + T_new;
+
+    auto xn = mlx::core::fast::rms_norm(*hidden, *norm1, (float)eps, device);
+    auto q_flat = qwen3_linear_in_out(xn, *q_proj, device);
+    auto k_flat = qwen3_linear_in_out(xn, *k_proj, device);
+    auto v_flat = qwen3_linear_in_out(xn, *v_proj, device);
+
+    auto q = mlx::core::reshape(q_flat, {B, T_new, N_q, D}, device);
+    auto k = mlx::core::reshape(k_flat, {B, T_new, N_kv, D}, device);
+    auto v = mlx::core::reshape(v_flat, {B, T_new, N_kv, D}, device);
+
+    q = mlx::core::fast::rms_norm(q, *q_norm, (float)eps, device);
+    k = mlx::core::fast::rms_norm(k, *k_norm, (float)eps, device);
+
+    auto q_bn = mlx::core::transpose(q, {0, 2, 1, 3}, device);
+    auto k_bn = mlx::core::transpose(k, {0, 2, 1, 3}, device);
+    auto v_bn = mlx::core::transpose(v, {0, 2, 1, 3}, device);
+
+    auto q_rope = mlx::core::fast::rope(
+        q_bn, D, false, (float)theta, 1.0f, offset, std::nullopt, device);
+    auto k_rope = mlx::core::fast::rope(
+        k_bn, D, false, (float)theta, 1.0f, offset, std::nullopt, device);
+
+    auto k_cache_owned = std::move(*k_cache);
+    auto v_cache_owned = std::move(*v_cache);
+
+    auto k_upd = mlx::core::slice_update(
+        k_cache_owned, k_rope,
+        to_shape({0, 0, offset, 0}),
+        to_shape({B, N_kv, valid_len, D}),
+        device);
+    auto v_upd = mlx::core::slice_update(
+        v_cache_owned, v_bn,
+        to_shape({0, 0, offset, 0}),
+        to_shape({B, N_kv, valid_len, D}),
+        device);
+
+    auto k_valid = mlx::core::slice(
+        k_upd, to_shape({0, 0, 0, 0}), to_shape({B, N_kv, valid_len, D}), device);
+    auto v_valid = mlx::core::slice(
+        v_upd, to_shape({0, 0, 0, 0}), to_shape({B, N_kv, valid_len, D}), device);
+
+    auto build_prefill_mask = [&]() -> mlx::core::array {
+      auto mask_dtype = q.dtype();
+      auto zero_val   = mlx::core::zeros({}, mask_dtype, device);
+      auto neginf_val = mlx::core::full({}, -std::numeric_limits<float>::infinity(), mask_dtype, device);
+      int kv_offset = valid_len - T_new;
+      auto row = mlx::core::reshape(
+          mlx::core::arange(T_new,     mlx::core::int32, device), {1, 1, T_new, 1},     device);
+      auto col = mlx::core::reshape(
+          mlx::core::arange(valid_len, mlx::core::int32, device), {1, 1, 1, valid_len}, device);
+      auto causal_bool = mlx::core::less_equal(
+          col, mlx::core::add(row, mlx::core::array(kv_offset, mlx::core::int32), device), device);
+      return mlx::core::where(causal_bool, zero_val, neginf_val, device);
+    };
+
+    auto attn_out_bn = (T_new == 1)
+      ? mlx::core::fast::scaled_dot_product_attention(
+            q_rope, k_valid, v_valid, (float)scale, "", std::nullopt, std::nullopt, device)
+      : mlx::core::fast::scaled_dot_product_attention(
+            q_rope, k_valid, v_valid, (float)scale, "array", build_prefill_mask(), std::nullopt, device);
+    auto attn_out_bthd = mlx::core::transpose(attn_out_bn, {0, 2, 1, 3}, device);
+    auto attn_out = mlx::core::reshape(attn_out_bthd, {B, T_new, attn_width}, device);
+    auto attn_projected = qwen3_linear_in_out(attn_out, *o_proj, device);
+    auto attn_hidden = mlx::core::add(*hidden, attn_projected, device);
+
+    auto xn2 = mlx::core::fast::rms_norm(attn_hidden, *norm2, (float)eps, device);
+    auto gate = qwen3_linear_in_out(xn2, *gate_proj, device);
+    auto up = qwen3_linear_in_out(xn2, *up_proj, device);
+    auto mlp = mlx::core::multiply(
+        mlx::core::multiply(gate, mlx::core::sigmoid(gate, device), device),
+        up,
+        device);
+    auto mlp_out = qwen3_linear_in_out(mlp, *down_proj, device);
+    auto out = mlx::core::add(attn_hidden, mlp_out, device);
+
+    ERL_NIF_TERM result_tuple[3];
+    result_tuple[0] = create_tensor_resource(env, out);
+    result_tuple[1] = create_tensor_resource(env, k_upd);
+    result_tuple[2] = create_tensor_resource(env, v_upd);
+
+    return nx::nif::ok(env, enif_make_tuple3(env, result_tuple[0], result_tuple[1], result_tuple[2]));
+  }
+  CATCH()
+}
+ASYNC_NIF(qwen3_layer)
+
+// qwen3_attention_residual — dense attention output projection + residual add.
+//
+// Inputs:
+//   hidden   — {B, T, H}
+//   attn_out — {B, T, I}
+//   o_proj   — {I, H}
+//
+// Returns hidden + attn_out @ o_proj as {B, T, H}.
+NIF(qwen3_attention_residual) {
+  TENSOR_PARAM(0, hidden);
+  TENSOR_PARAM(1, attn_out);
+  TENSOR_PARAM(2, o_proj);
+  DEVICE_PARAM(3, device);
+
+  try {
+    std::string error;
+    if (!qwen3_check_rank3_positive(*hidden, "hidden", error) ||
+        !qwen3_check_rank3_positive(*attn_out, "attn_out", error)) {
+      return qwen3_error(env, error);
+    }
+
+    int B = hidden->shape(0);
+    int T = hidden->shape(1);
+    int H = hidden->shape(2);
+    if (!qwen3_check_dim(*attn_out, 0, B, "attn_out", "batch", error) ||
+        !qwen3_check_dim(*attn_out, 1, T, "attn_out", "sequence length", error) ||
+        !qwen3_check_rank2_positive(*o_proj, "o_proj", error) ||
+        !qwen3_check_dim(*o_proj, 0, attn_out->shape(2), "o_proj", "input width", error) ||
+        !qwen3_check_dim(*o_proj, 1, H, "o_proj", "output width", error)) {
+      return qwen3_error(env, error);
+    }
+
+    auto projected = qwen3_linear_in_out(*attn_out, *o_proj, device);
+    auto residual = mlx::core::add(*hidden, projected, device);
+
+    TENSOR(residual);
+  }
+  CATCH()
+}
+ASYNC_NIF(qwen3_attention_residual)
+
+// qwen3_attention_block — dense Qwen3 attention block:
+// input RMSNorm + Q/K/V projections + Q/K RMSNorm + RoPE + KV update + SDPA
+// + output projection + residual add.
+//
+// Inputs:
+//   hidden   — {B, T_new, H}       pre-attention residual hidden state
+//   norm     — {H}                 input RMSNorm weight
+//   q_proj   — {H, N_q * D}
+//   k_proj   — {H, N_kv * D}
+//   v_proj   — {H, N_kv * D}
+//   o_proj   — {N_q * D, H}
+//   q_norm   — {D}
+//   k_norm   — {D}
+//   k_cache  — {B, N_kv, T_max, D}
+//   v_cache  — {B, N_kv, T_max, D}
+//   offset   — int
+//   scale    — float
+//   head_dim — int
+//   theta    — float
+//   eps      — RMSNorm epsilon
+//
+// Returns {hidden_out, k_upd, v_upd}.
+NIF(qwen3_attention_block) {
+  TENSOR_PARAM(0, hidden);
+  TENSOR_PARAM(1, norm);
+  TENSOR_PARAM(2, q_proj);
+  TENSOR_PARAM(3, k_proj);
+  TENSOR_PARAM(4, v_proj);
+  TENSOR_PARAM(5, o_proj);
+  TENSOR_PARAM(6, q_norm);
+  TENSOR_PARAM(7, k_norm);
+  TENSOR_PARAM(8, k_cache);
+  TENSOR_PARAM(9, v_cache);
+  PARAM(10, int, offset);
+  PARAM(11, double, scale);
+  PARAM(12, int, head_dim);
+  PARAM(13, double, theta);
+  PARAM(14, double, eps);
+  DEVICE_PARAM(15, device);
+
+  try {
+    std::string error;
+    if (!qwen3_check_rank3_positive(*hidden, "hidden", error) ||
+        !qwen3_check_non_negative(offset, "offset", error) ||
+        !qwen3_check_positive(head_dim, "head_dim", error)) {
+      return qwen3_error(env, error);
+    }
+
+    int B       = hidden->shape(0);
+    int T_new   = hidden->shape(1);
+    int H       = hidden->shape(2);
+    int D       = head_dim;
+    if (!qwen3_check_rank1_dim(*norm, H, "norm", error) ||
+        !qwen3_check_rank1_dim(*q_norm, D, "q_norm", error) ||
+        !qwen3_check_rank1_dim(*k_norm, D, "k_norm", error) ||
+        !qwen3_check_rank2_positive(*q_proj, "q_proj", error) ||
+        !qwen3_check_rank2_positive(*k_proj, "k_proj", error) ||
+        !qwen3_check_rank2_positive(*v_proj, "v_proj", error) ||
+        !qwen3_check_dim(*q_proj, 0, H, "q_proj", "input width", error) ||
+        !qwen3_check_dim(*k_proj, 0, H, "k_proj", "input width", error) ||
+        !qwen3_check_dim(*v_proj, 0, H, "v_proj", "input width", error)) {
+      return qwen3_error(env, error);
+    }
+
+    if ((q_proj->shape(1) % D) != 0 || (k_proj->shape(1) % D) != 0) {
+      return qwen3_error(env, "projection output widths must be divisible by head_dim");
+    }
+    if (v_proj->shape(1) != k_proj->shape(1)) {
+      return qwen3_error(env, "v_proj output width must match k_proj output width");
+    }
+
+    int N_q     = q_proj->shape(1) / D;
+    int N_kv    = k_proj->shape(1) / D;
+    int attn_width = N_q * D;
+
+    if ((N_q % N_kv) != 0) {
+      return qwen3_error(env, "query heads must be divisible by key/value heads");
+    }
+    if (!qwen3_check_rank2_positive(*o_proj, "o_proj", error) ||
+        !qwen3_check_dim(*o_proj, 0, attn_width, "o_proj", "input width", error) ||
+        !qwen3_check_dim(*o_proj, 1, H, "o_proj", "output width", error) ||
+        !qwen3_validate_kv_cache_bn(*k_cache, *v_cache, B, N_kv, offset, T_new, D, error)) {
+      return qwen3_error(env, error);
+    }
+    int valid_len = offset + T_new;
+
+    auto xn = mlx::core::fast::rms_norm(*hidden, *norm, (float)eps, device);
+    auto q_flat = qwen3_linear_in_out(xn, *q_proj, device);
+    auto k_flat = qwen3_linear_in_out(xn, *k_proj, device);
+    auto v_flat = qwen3_linear_in_out(xn, *v_proj, device);
+
+    auto q = mlx::core::reshape(q_flat, {B, T_new, N_q, D}, device);
+    auto k = mlx::core::reshape(k_flat, {B, T_new, N_kv, D}, device);
+    auto v = mlx::core::reshape(v_flat, {B, T_new, N_kv, D}, device);
+
+    q = mlx::core::fast::rms_norm(q, *q_norm, (float)eps, device);
+    k = mlx::core::fast::rms_norm(k, *k_norm, (float)eps, device);
+
+    auto q_bn = mlx::core::transpose(q, {0, 2, 1, 3}, device);
+    auto k_bn = mlx::core::transpose(k, {0, 2, 1, 3}, device);
+    auto v_bn = mlx::core::transpose(v, {0, 2, 1, 3}, device);
+
+    auto q_rope = mlx::core::fast::rope(
+        q_bn, D, false, (float)theta, 1.0f, offset, std::nullopt, device);
+    auto k_rope = mlx::core::fast::rope(
+        k_bn, D, false, (float)theta, 1.0f, offset, std::nullopt, device);
+
+    auto k_cache_owned = std::move(*k_cache);
+    auto v_cache_owned = std::move(*v_cache);
+
+    auto k_upd = mlx::core::slice_update(
+        k_cache_owned, k_rope,
+        to_shape({0, 0, offset, 0}),
+        to_shape({B, N_kv, valid_len, D}),
+        device);
+    auto v_upd = mlx::core::slice_update(
+        v_cache_owned, v_bn,
+        to_shape({0, 0, offset, 0}),
+        to_shape({B, N_kv, valid_len, D}),
+        device);
+
+    auto k_valid = mlx::core::slice(
+        k_upd, to_shape({0, 0, 0, 0}), to_shape({B, N_kv, valid_len, D}), device);
+    auto v_valid = mlx::core::slice(
+        v_upd, to_shape({0, 0, 0, 0}), to_shape({B, N_kv, valid_len, D}), device);
+
+    auto build_prefill_mask = [&]() -> mlx::core::array {
+      auto mask_dtype = q.dtype();
+      auto zero_val   = mlx::core::zeros({}, mask_dtype, device);
+      auto neginf_val = mlx::core::full({}, -std::numeric_limits<float>::infinity(), mask_dtype, device);
+      int kv_offset = valid_len - T_new;
+      auto row = mlx::core::reshape(
+          mlx::core::arange(T_new,     mlx::core::int32, device), {1, 1, T_new, 1},     device);
+      auto col = mlx::core::reshape(
+          mlx::core::arange(valid_len, mlx::core::int32, device), {1, 1, 1, valid_len}, device);
+      auto causal_bool = mlx::core::less_equal(
+          col, mlx::core::add(row, mlx::core::array(kv_offset, mlx::core::int32), device), device);
+      return mlx::core::where(causal_bool, zero_val, neginf_val, device);
+    };
+
+    auto attn_out_bn = (T_new == 1)
+      ? mlx::core::fast::scaled_dot_product_attention(
+            q_rope, k_valid, v_valid, (float)scale, "", std::nullopt, std::nullopt, device)
+      : mlx::core::fast::scaled_dot_product_attention(
+            q_rope, k_valid, v_valid, (float)scale, "array", build_prefill_mask(), std::nullopt, device);
+    auto attn_out_bthd = mlx::core::transpose(attn_out_bn, {0, 2, 1, 3}, device);
+    auto attn_out = mlx::core::reshape(attn_out_bthd, {B, T_new, attn_width}, device);
+    auto projected = qwen3_linear_in_out(attn_out, *o_proj, device);
+    auto out = mlx::core::add(*hidden, projected, device);
+
+    ERL_NIF_TERM result_tuple[3];
+    result_tuple[0] = create_tensor_resource(env, out);
+    result_tuple[1] = create_tensor_resource(env, k_upd);
+    result_tuple[2] = create_tensor_resource(env, v_upd);
+
+    return nx::nif::ok(env, enif_make_tuple3(env, result_tuple[0], result_tuple[1], result_tuple[2]));
+  }
+  CATCH()
+}
+ASYNC_NIF(qwen3_attention_block)

--- a/emlx/c_src/emlx_nif.cpp
+++ b/emlx/c_src/emlx_nif.cpp
@@ -1452,6 +1452,11 @@ ERL_NIF_TERM fast_swiglu_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
 ERL_NIF_TERM kv_cache_attention_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
 ERL_NIF_TERM kv_cache_attention_masked_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
 ERL_NIF_TERM kv_cache_sdpa_update_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM qwen3_kv_cache_attention_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM qwen3_mlp_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM qwen3_layer_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM qwen3_attention_residual_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM qwen3_attention_block_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
 
 // ─── Async wrappers ────────────────────────────────────────────────────────
 
@@ -1985,6 +1990,11 @@ static ErlNifFunc nif_funcs[] = {
     {"fast_swiglu", 4, fast_swiglu_async},
     {"kv_cache_attention", 9, kv_cache_attention_async},
     {"kv_cache_attention_masked", 10, kv_cache_attention_masked_async},
-    {"kv_cache_sdpa_update", 9, kv_cache_sdpa_update_async}};
+    {"kv_cache_sdpa_update", 9, kv_cache_sdpa_update_async},
+    {"qwen3_kv_cache_attention", 11, qwen3_kv_cache_attention_async},
+    {"qwen3_mlp", 8, qwen3_mlp_async},
+    {"qwen3_layer", 21, qwen3_layer_async},
+    {"qwen3_attention_residual", 5, qwen3_attention_residual_async},
+    {"qwen3_attention_block", 17, qwen3_attention_block_async}};
 
 ERL_NIF_INIT(Elixir.EMLX.NIF, nif_funcs, load, NULL, upgrade, NULL)

--- a/emlx/lib/emlx.ex
+++ b/emlx/lib/emlx.ex
@@ -148,6 +148,7 @@ defmodule EMLX do
   end
 
   defguard is_tensor(device, ref) when is_reference(ref) and is_atom(device)
+  @type tensor_ref :: {atom(), reference()}
 
   ## Macro callbacks
 
@@ -950,6 +951,297 @@ defmodule EMLX do
       |> await_worker()
 
     {{effective_device, attn_ref}, {effective_device, k_upd_ref}, {effective_device, v_upd_ref}}
+  end
+
+  @doc """
+  Qwen3-specific fused RoPE + KV cache update + SDPA for the native decode path.
+
+  Accepts `query`, `new_key`, and `new_value` in projection layout
+  `{B, T, N, D}`. The NIF transposes Q/K/V, applies Qwen3 RoPE to Q/K, updates
+  the owned KV cache, runs SDPA, and returns flattened projection-ready
+  attention output `{B, T, N * D}` plus updated cache refs.
+  """
+  @mlx_function {:qwen3_kv_cache_attention, 11}
+  def qwen3_kv_cache_attention(
+        {dev_q, ref_q},
+        {_dev_k, ref_k},
+        {_dev_v, ref_v},
+        {_dev_kc, ref_kc},
+        {_dev_vc, ref_vc},
+        offset,
+        scale,
+        head_dim,
+        theta
+      )
+      when is_tensor(dev_q, ref_q) and is_integer(offset) and is_float(scale) and
+             is_integer(head_dim) and is_number(theta) do
+    device = dev_q
+    {worker, effective_device} = resolve_worker(device)
+
+    {attn_ref, k_upd_ref, v_upd_ref} =
+      EMLX.NIF.qwen3_kv_cache_attention(
+        worker,
+        ref_q,
+        ref_k,
+        ref_v,
+        ref_kc,
+        ref_vc,
+        offset,
+        scale,
+        head_dim,
+        theta * 1.0,
+        effective_device
+      )
+      |> unwrap!()
+      |> await_worker()
+
+    {{effective_device, attn_ref}, {effective_device, k_upd_ref}, {effective_device, v_upd_ref}}
+  end
+
+  @doc """
+  Qwen3-specific dense MLP helper.
+
+  Accepts hidden states `{B, T, H}`, post-attention RMSNorm weight `{H}`,
+  dense gate/up projections `{H, I}`, dense down projection `{I, H}`, and RMSNorm
+  epsilon. Returns `hidden + mlp_output` as `{B, T, H}`.
+  """
+  @mlx_function {:qwen3_mlp, 8}
+  def qwen3_mlp(
+        {dev_h, ref_h},
+        {_dev_norm, ref_norm},
+        {_dev_gate, ref_gate},
+        {_dev_up, ref_up},
+        {_dev_down, ref_down},
+        eps
+      )
+      when is_tensor(dev_h, ref_h) and is_float(eps) do
+    device = dev_h
+    {worker, effective_device} = resolve_worker(device)
+
+    out_ref =
+      EMLX.NIF.qwen3_mlp(
+        worker,
+        ref_h,
+        ref_norm,
+        ref_gate,
+        ref_up,
+        ref_down,
+        eps,
+        effective_device
+      )
+      |> unwrap!()
+      |> await_worker()
+
+    {effective_device, out_ref}
+  end
+
+  @doc """
+  Qwen3-specific dense attention output projection plus residual add.
+
+  Accepts residual hidden state `{B, T, H}`, flattened attention output
+  `{B, T, I}`, and dense output projection `{I, H}`. Returns
+  `hidden + projected_attention`.
+  """
+  @mlx_function {:qwen3_attention_residual, 5}
+  def qwen3_attention_residual(
+        {dev_h, ref_h},
+        {_dev_attn, ref_attn},
+        {_dev_o, ref_o}
+      )
+      when is_tensor(dev_h, ref_h) do
+    device = dev_h
+    {worker, effective_device} = resolve_worker(device)
+
+    out_ref =
+      EMLX.NIF.qwen3_attention_residual(
+        worker,
+        ref_h,
+        ref_attn,
+        ref_o,
+        effective_device
+      )
+      |> unwrap!()
+      |> await_worker()
+
+    {effective_device, out_ref}
+  end
+
+  @doc """
+  Qwen3-specific dense transformer layer helper.
+
+  Accepts hidden states `{B, T, H}`, input/post-attention RMSNorm weights,
+  dense attention projections, Q/K RMSNorm weights, owned KV cache refs, dense
+  MLP projections, offset, scale, RoPE parameters, and RMSNorm epsilon. Returns
+  `{hidden_out, k_cache, v_cache}`.
+  """
+  @mlx_function {:qwen3_layer, 21}
+  def qwen3_layer(
+        {dev_h, ref_h},
+        {_dev_norm1, ref_norm1},
+        {_dev_q, ref_q},
+        {_dev_k, ref_k},
+        {_dev_v, ref_v},
+        {_dev_o, ref_o},
+        {_dev_qn, ref_qn},
+        {_dev_kn, ref_kn},
+        {_dev_kc, ref_kc},
+        {_dev_vc, ref_vc},
+        {_dev_norm2, ref_norm2},
+        {_dev_gate, ref_gate},
+        {_dev_up, ref_up},
+        {_dev_down, ref_down},
+        offset,
+        scale,
+        head_dim,
+        theta,
+        eps
+      )
+      when is_tensor(dev_h, ref_h) and is_integer(offset) and is_float(scale) and
+             is_integer(head_dim) and is_number(theta) and is_float(eps) do
+    device = dev_h
+    {worker, effective_device} = resolve_worker(device)
+
+    {out_ref, k_upd_ref, v_upd_ref} =
+      EMLX.NIF.qwen3_layer(
+        worker,
+        ref_h,
+        ref_norm1,
+        ref_q,
+        ref_k,
+        ref_v,
+        ref_o,
+        ref_qn,
+        ref_kn,
+        ref_kc,
+        ref_vc,
+        ref_norm2,
+        ref_gate,
+        ref_up,
+        ref_down,
+        offset,
+        scale,
+        head_dim,
+        theta * 1.0,
+        eps,
+        effective_device
+      )
+      |> unwrap!()
+      |> await_worker()
+
+    {{effective_device, out_ref}, {effective_device, k_upd_ref}, {effective_device, v_upd_ref}}
+  end
+
+  @doc """
+  Qwen3-specific dense attention block helper.
+
+  Accepts pre-attention residual hidden state `{B, T, H}`, input RMSNorm weight
+  `{H}`, dense Q/K/V/O projections, Q/K RMSNorm weights, owned KV cache refs,
+  offset, scale, RoPE parameters, and RMSNorm epsilon. Returns
+  `{hidden_out, k_cache, v_cache}`.
+  """
+  @mlx_function {:qwen3_attention_block, 17}
+  def qwen3_attention_block(
+        {dev_h, ref_h},
+        {_dev_norm, ref_norm},
+        {_dev_q, ref_q},
+        {_dev_k, ref_k},
+        {_dev_v, ref_v},
+        {_dev_o, ref_o},
+        {_dev_qn, ref_qn},
+        {_dev_kn, ref_kn},
+        {_dev_kc, ref_kc},
+        {_dev_vc, ref_vc},
+        offset,
+        scale,
+        head_dim,
+        theta,
+        eps
+      )
+      when is_tensor(dev_h, ref_h) and is_integer(offset) and is_float(scale) and
+             is_integer(head_dim) and is_number(theta) and is_float(eps) do
+    device = dev_h
+    {worker, effective_device} = resolve_worker(device)
+
+    {out_ref, k_upd_ref, v_upd_ref} =
+      EMLX.NIF.qwen3_attention_block(
+        worker,
+        ref_h,
+        ref_norm,
+        ref_q,
+        ref_k,
+        ref_v,
+        ref_o,
+        ref_qn,
+        ref_kn,
+        ref_kc,
+        ref_vc,
+        offset,
+        scale,
+        head_dim,
+        theta * 1.0,
+        eps,
+        effective_device
+      )
+      |> unwrap!()
+      |> await_worker()
+
+    {{effective_device, out_ref}, {effective_device, k_upd_ref}, {effective_device, v_upd_ref}}
+  end
+
+  @doc """
+  Stable wrapper for causal self-attention with an owned KV cache.
+
+  This is the public semantic API for Qwen/Llama-style decode paths that need
+  compact GQA KV heads, fused cache update, valid-prefix slicing, and causal
+  SDPA through EMLX's native MLX kernels.
+
+  Inputs use Bumblebee convention:
+
+  - `query` — `{B, T_q, N_q, D}`
+  - `new_key` / `new_value` — `{B, T_new, N_kv, D}`
+  - `key_cache` / `value_cache` — `{B, T_max, N_kv, D}`
+  - `offset` — integer count of positions already present in the cache
+
+  Options:
+
+  - `:scale` — required float, usually `1 / sqrt(head_dim)`
+  - `:key_mask` — optional `{B, offset + T_new}` mask with `1` = attend and
+    `0` = skip padding
+
+  Returns `{attention, updated_key_cache, updated_value_cache}` as raw EMLX
+  `{device, ref}` pairs. Keeping the caches in this representation lets callers
+  store and reuse device-resident cache buffers without converting them back to
+  `Nx.Tensor` between decode steps.
+  """
+  @spec causal_kv_attention(
+          tensor_ref(),
+          tensor_ref(),
+          tensor_ref(),
+          tensor_ref(),
+          tensor_ref(),
+          non_neg_integer(),
+          keyword()
+        ) :: {tensor_ref(), tensor_ref(), tensor_ref()}
+  def causal_kv_attention(query, new_key, new_value, key_cache, value_cache, offset, opts)
+      when is_integer(offset) and offset >= 0 and is_list(opts) do
+    scale = Keyword.fetch!(opts, :scale)
+
+    case Keyword.get(opts, :key_mask) do
+      nil ->
+        kv_cache_attention(query, new_key, new_value, key_cache, value_cache, offset, scale)
+
+      key_mask ->
+        kv_cache_attention_masked(
+          query,
+          new_key,
+          new_value,
+          key_cache,
+          value_cache,
+          offset,
+          scale,
+          key_mask
+        )
+    end
   end
 
   @doc """

--- a/emlx/test/emlx/fast_test.exs
+++ b/emlx/test/emlx/fast_test.exs
@@ -871,6 +871,69 @@ defmodule EMLX.FastTest do
       )
     end
 
+    test "qwen3_layer matches pure Nx reference for batched GQA" do
+      fixtures = qwen3_batched_dense_attention_fixtures()
+      scale = 1.0 / :math.sqrt(fixtures.head_dim)
+
+      {out_ref, k_ref, v_ref} =
+        EMLX.qwen3_layer(
+          EMLX.Backend.from_nx(gpu(fixtures.hidden)),
+          EMLX.Backend.from_nx(gpu(fixtures.norm1)),
+          EMLX.Backend.from_nx(gpu(fixtures.q_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.v_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.o_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.q_norm)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_norm)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_cache)),
+          EMLX.Backend.from_nx(gpu(fixtures.v_cache)),
+          EMLX.Backend.from_nx(gpu(fixtures.norm2)),
+          EMLX.Backend.from_nx(gpu(fixtures.gate_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.up_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.down_proj)),
+          fixtures.offset,
+          scale,
+          fixtures.head_dim,
+          fixtures.theta,
+          fixtures.eps
+        )
+
+      {attn_expected, expected_k, expected_v} = qwen3_attention_block_reference(fixtures)
+
+      expected =
+        qwen3_mlp_reference(
+          attn_expected,
+          fixtures.norm2,
+          fixtures.gate_proj,
+          fixtures.up_proj,
+          fixtures.down_proj,
+          fixtures.eps
+        )
+
+      assert Nx.shape(expected) == {2, 2, 4}
+
+      assert_all_close(
+        out_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        k_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_k,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        v_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_v,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+    end
+
     test "qwen3_attention_residual matches pure Nx reference" do
       {hidden, attn_out, o_proj} =
         Nx.with_default_backend(Nx.BinaryBackend, fn ->
@@ -1049,12 +1112,16 @@ defmodule EMLX.FastTest do
       %{
         hidden: Nx.iota({2, 2, 4}, type: :f32) |> Nx.add(1) |> Nx.divide(20),
         norm1: Nx.tensor([1.0, 1.1, 0.9, 1.2], type: :f32),
+        norm2: Nx.tensor([1.2, 0.8, 1.1, 0.95], type: :f32),
         q_norm: Nx.tensor([1.0, 1.1], type: :f32),
         k_norm: Nx.tensor([0.9, 1.2], type: :f32),
         q_proj: Nx.iota({4, 8}, type: :f32) |> Nx.add(1) |> Nx.divide(80),
         k_proj: Nx.iota({4, 4}, type: :f32) |> Nx.add(3) |> Nx.divide(90),
         v_proj: Nx.iota({4, 4}, type: :f32) |> Nx.add(5) |> Nx.divide(100),
         o_proj: Nx.iota({8, 4}, type: :f32) |> Nx.add(7) |> Nx.divide(110),
+        gate_proj: Nx.iota({4, 6}, type: :f32) |> Nx.add(13) |> Nx.divide(120),
+        up_proj: Nx.iota({4, 6}, type: :f32) |> Nx.add(29) |> Nx.divide(130),
+        down_proj: Nx.iota({6, 4}, type: :f32) |> Nx.add(41) |> Nx.divide(140),
         k_cache: Nx.iota({2, 2, 6, 2}, type: :f32) |> Nx.add(11) |> Nx.divide(1_000),
         v_cache: Nx.iota({2, 2, 6, 2}, type: :f32) |> Nx.add(101) |> Nx.divide(1_000),
         offset: 2,

--- a/emlx/test/emlx/fast_test.exs
+++ b/emlx/test/emlx/fast_test.exs
@@ -260,4 +260,1110 @@ defmodule EMLX.FastTest do
       assert Nx.type(out) == {:f, 16}
     end
   end
+
+  describe "EMLX.kv_cache_sdpa_update/7" do
+    test "preserves BNHD value input and attention output contract" do
+      q = Nx.iota({1, 2, 3, 4}, type: :f32) |> Nx.divide(100) |> gpu()
+      new_k = Nx.iota({1, 1, 3, 4}, type: :f32) |> Nx.divide(200) |> gpu()
+      new_v = Nx.iota({1, 1, 3, 4}, type: :f32) |> Nx.divide(300) |> gpu()
+      k_cache = Nx.broadcast(0.0, {1, 1, 5, 4}) |> Nx.as_type(:f32) |> gpu()
+      v_cache = Nx.broadcast(0.0, {1, 1, 5, 4}) |> Nx.as_type(:f32) |> gpu()
+
+      {attn_ref, k_upd_ref, v_upd_ref} =
+        EMLX.kv_cache_sdpa_update(
+          EMLX.Backend.from_nx(q),
+          EMLX.Backend.from_nx(new_k),
+          EMLX.Backend.from_nx(new_v),
+          EMLX.Backend.from_nx(k_cache),
+          EMLX.Backend.from_nx(v_cache),
+          0,
+          1.0 / :math.sqrt(4)
+        )
+
+      attn = EMLX.Backend.to_nx(attn_ref)
+      k_upd = EMLX.Backend.to_nx(k_upd_ref)
+      v_upd = EMLX.Backend.to_nx(v_upd_ref)
+
+      assert Nx.shape(attn) == {1, 2, 3, 4}
+      assert Nx.shape(k_upd) == {1, 1, 5, 4}
+      assert Nx.shape(v_upd) == {1, 1, 5, 4}
+
+      assert_all_close(
+        Nx.slice_along_axis(k_upd, 0, 3, axis: 2) |> Nx.backend_transfer(),
+        Nx.backend_transfer(new_k),
+        atol: 1.0e-5
+      )
+
+      assert_all_close(
+        Nx.slice_along_axis(v_upd, 0, 3, axis: 2) |> Nx.backend_transfer(),
+        Nx.backend_transfer(new_v),
+        atol: 1.0e-5
+      )
+    end
+  end
+
+  describe "EMLX.causal_kv_attention/7" do
+    test "prefill updates compact GQA cache and returns attention output" do
+      {q_cpu, new_k_cpu, new_v_cpu, k_cache_cpu, v_cache_cpu, key_mask_cpu} =
+        Nx.with_default_backend(Nx.BinaryBackend, fn ->
+          {
+            Nx.iota({1, 3, 4, 8}, type: :f32) |> Nx.divide(100),
+            Nx.iota({1, 3, 2, 8}, type: :f32) |> Nx.divide(200),
+            Nx.iota({1, 3, 2, 8}, type: :f32) |> Nx.divide(300),
+            Nx.broadcast(0.0, {1, 5, 2, 8}) |> Nx.as_type(:f32),
+            Nx.broadcast(0.0, {1, 5, 2, 8}) |> Nx.as_type(:f32),
+            Nx.tensor([[1, 1, 1]], type: :u8)
+          }
+        end)
+
+      scale = 1.0 / :math.sqrt(8)
+
+      expected_attn =
+        causal_kv_attention_reference(
+          q_cpu,
+          new_k_cpu,
+          new_v_cpu,
+          k_cache_cpu,
+          v_cache_cpu,
+          0,
+          scale,
+          key_mask_cpu
+        )
+
+      q = gpu(q_cpu)
+      new_k = gpu(new_k_cpu)
+      new_v = gpu(new_v_cpu)
+      k_cache = gpu(k_cache_cpu)
+      v_cache = gpu(v_cache_cpu)
+      key_mask = gpu(key_mask_cpu)
+
+      {attn_ref, k_upd_ref, v_upd_ref} =
+        EMLX.causal_kv_attention(
+          EMLX.Backend.from_nx(q),
+          EMLX.Backend.from_nx(new_k),
+          EMLX.Backend.from_nx(new_v),
+          EMLX.Backend.from_nx(k_cache),
+          EMLX.Backend.from_nx(v_cache),
+          0,
+          scale: scale,
+          key_mask: EMLX.Backend.from_nx(key_mask)
+        )
+
+      attn = EMLX.Backend.to_nx(attn_ref)
+      k_upd = EMLX.Backend.to_nx(k_upd_ref)
+      v_upd = EMLX.Backend.to_nx(v_upd_ref)
+
+      assert Nx.shape(attn) == {1, 3, 4, 8}
+      assert Nx.shape(k_upd) == {1, 5, 2, 8}
+      assert Nx.shape(v_upd) == {1, 5, 2, 8}
+
+      assert_all_close(
+        Nx.backend_transfer(attn, Nx.BinaryBackend),
+        expected_attn,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        Nx.slice_along_axis(k_upd, 0, 3, axis: 1) |> Nx.backend_transfer(),
+        Nx.backend_transfer(new_k),
+        atol: 1.0e-5
+      )
+
+      assert_all_close(
+        Nx.slice_along_axis(v_upd, 0, 3, axis: 1) |> Nx.backend_transfer(),
+        Nx.backend_transfer(new_v),
+        atol: 1.0e-5
+      )
+    end
+
+    test "decode appends one token after prefill and keeps output dtype" do
+      {q_prefill_cpu, k_prefill_cpu, v_prefill_cpu, k_cache_cpu, v_cache_cpu} =
+        Nx.with_default_backend(Nx.BinaryBackend, fn ->
+          {
+            Nx.iota({1, 3, 4, 8}, type: :f32) |> Nx.divide(100),
+            Nx.iota({1, 3, 2, 8}, type: :f32) |> Nx.divide(200),
+            Nx.iota({1, 3, 2, 8}, type: :f32) |> Nx.divide(300),
+            Nx.broadcast(0.0, {1, 5, 2, 8}) |> Nx.as_type(:f32),
+            Nx.broadcast(0.0, {1, 5, 2, 8}) |> Nx.as_type(:f32)
+          }
+        end)
+
+      scale = 1.0 / :math.sqrt(8)
+
+      q_prefill = gpu(q_prefill_cpu)
+      k_prefill = gpu(k_prefill_cpu)
+      v_prefill = gpu(v_prefill_cpu)
+      k_cache = gpu(k_cache_cpu)
+      v_cache = gpu(v_cache_cpu)
+
+      {_attn_ref, k_cache_ref, v_cache_ref} =
+        EMLX.causal_kv_attention(
+          EMLX.Backend.from_nx(q_prefill),
+          EMLX.Backend.from_nx(k_prefill),
+          EMLX.Backend.from_nx(v_prefill),
+          EMLX.Backend.from_nx(k_cache),
+          EMLX.Backend.from_nx(v_cache),
+          0,
+          scale: scale,
+          key_mask: EMLX.Backend.from_nx(Nx.tensor([[1, 1, 1]], type: :u8) |> gpu())
+        )
+
+      {q_decode_cpu, k_decode_cpu, v_decode_cpu, decode_key_mask_cpu} =
+        Nx.with_default_backend(Nx.BinaryBackend, fn ->
+          {
+            Nx.iota({1, 1, 4, 8}, type: :f32) |> Nx.add(100) |> Nx.divide(100),
+            Nx.iota({1, 1, 2, 8}, type: :f32) |> Nx.add(100) |> Nx.divide(200),
+            Nx.iota({1, 1, 2, 8}, type: :f32) |> Nx.add(100) |> Nx.divide(300),
+            Nx.tensor([[1, 1, 1, 1]], type: :u8)
+          }
+        end)
+
+      k_cache_after_prefill =
+        Nx.put_slice(k_cache_cpu, [0, 0, 0, 0], k_prefill_cpu)
+
+      v_cache_after_prefill =
+        Nx.put_slice(v_cache_cpu, [0, 0, 0, 0], v_prefill_cpu)
+
+      expected =
+        causal_kv_attention_reference(
+          q_decode_cpu,
+          k_decode_cpu,
+          v_decode_cpu,
+          k_cache_after_prefill,
+          v_cache_after_prefill,
+          3,
+          scale,
+          decode_key_mask_cpu
+        )
+
+      q_decode = gpu(q_decode_cpu)
+      k_decode = gpu(k_decode_cpu)
+      v_decode = gpu(v_decode_cpu)
+
+      {attn_ref, k_upd_ref, v_upd_ref} =
+        EMLX.causal_kv_attention(
+          EMLX.Backend.from_nx(q_decode),
+          EMLX.Backend.from_nx(k_decode),
+          EMLX.Backend.from_nx(v_decode),
+          k_cache_ref,
+          v_cache_ref,
+          3,
+          scale: scale,
+          key_mask: EMLX.Backend.from_nx(Nx.tensor([[1, 1, 1, 1]], type: :u8) |> gpu())
+        )
+
+      attn = EMLX.Backend.to_nx(attn_ref)
+      k_upd = EMLX.Backend.to_nx(k_upd_ref)
+      v_upd = EMLX.Backend.to_nx(v_upd_ref)
+
+      assert Nx.shape(attn) == {1, 1, 4, 8}
+      assert Nx.type(attn) == {:f, 32}
+
+      assert_all_close(Nx.backend_transfer(attn, Nx.BinaryBackend), expected,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        Nx.slice_along_axis(k_upd, 3, 1, axis: 1) |> Nx.backend_transfer(),
+        Nx.backend_transfer(k_decode),
+        atol: 1.0e-5
+      )
+
+      assert_all_close(
+        Nx.slice_along_axis(v_upd, 3, 1, axis: 1) |> Nx.backend_transfer(),
+        Nx.backend_transfer(v_decode),
+        atol: 1.0e-5
+      )
+    end
+  end
+
+  describe "EMLX.qwen3_kv_cache_attention/9 validation" do
+    test "rejects malformed Q rank before reading shapes" do
+      q = Nx.broadcast(0.0, {1, 1, 4}) |> Nx.as_type(:f16) |> gpu()
+      k = Nx.broadcast(0.0, {1, 1, 1, 4}) |> Nx.as_type(:f16) |> gpu()
+      v = Nx.broadcast(0.0, {1, 1, 1, 4}) |> Nx.as_type(:f16) |> gpu()
+      k_cache = Nx.broadcast(0.0, {1, 1, 4, 4}) |> Nx.as_type(:f16) |> gpu()
+      v_cache = Nx.broadcast(0.0, {1, 1, 4, 4}) |> Nx.as_type(:f16) |> gpu()
+
+      assert_raise EMLX.NIFError, ~r/q expects rank 4/, fn ->
+        EMLX.qwen3_kv_cache_attention(
+          EMLX.Backend.from_nx(q),
+          EMLX.Backend.from_nx(k),
+          EMLX.Backend.from_nx(v),
+          EMLX.Backend.from_nx(k_cache),
+          EMLX.Backend.from_nx(v_cache),
+          0,
+          1.0 / :math.sqrt(4),
+          4,
+          10_000.0
+        )
+      end
+    end
+
+    test "rejects negative offsets" do
+      q = Nx.broadcast(0.0, {1, 1, 2, 4}) |> Nx.as_type(:f16) |> gpu()
+      k = Nx.broadcast(0.0, {1, 1, 1, 4}) |> Nx.as_type(:f16) |> gpu()
+      v = Nx.broadcast(0.0, {1, 1, 1, 4}) |> Nx.as_type(:f16) |> gpu()
+      k_cache = Nx.broadcast(0.0, {1, 1, 4, 4}) |> Nx.as_type(:f16) |> gpu()
+      v_cache = Nx.broadcast(0.0, {1, 1, 4, 4}) |> Nx.as_type(:f16) |> gpu()
+
+      assert_raise EMLX.NIFError, ~r/offset must be non-negative/, fn ->
+        EMLX.qwen3_kv_cache_attention(
+          EMLX.Backend.from_nx(q),
+          EMLX.Backend.from_nx(k),
+          EMLX.Backend.from_nx(v),
+          EMLX.Backend.from_nx(k_cache),
+          EMLX.Backend.from_nx(v_cache),
+          -1,
+          1.0 / :math.sqrt(4),
+          4,
+          10_000.0
+        )
+      end
+    end
+
+    test "rejects cache capacity overflow" do
+      q = Nx.broadcast(0.0, {1, 1, 2, 4}) |> Nx.as_type(:f16) |> gpu()
+      k = Nx.broadcast(0.0, {1, 1, 1, 4}) |> Nx.as_type(:f16) |> gpu()
+      v = Nx.broadcast(0.0, {1, 1, 1, 4}) |> Nx.as_type(:f16) |> gpu()
+      k_cache = Nx.broadcast(0.0, {1, 1, 4, 4}) |> Nx.as_type(:f16) |> gpu()
+      v_cache = Nx.broadcast(0.0, {1, 1, 4, 4}) |> Nx.as_type(:f16) |> gpu()
+
+      assert_raise EMLX.NIFError, ~r/KV cache capacity 4 is smaller than required length 5/, fn ->
+        EMLX.qwen3_kv_cache_attention(
+          EMLX.Backend.from_nx(q),
+          EMLX.Backend.from_nx(k),
+          EMLX.Backend.from_nx(v),
+          EMLX.Backend.from_nx(k_cache),
+          EMLX.Backend.from_nx(v_cache),
+          4,
+          1.0 / :math.sqrt(4),
+          4,
+          10_000.0
+        )
+      end
+    end
+
+    test "matches pure Nx reference for GQA prefill and updates caches" do
+      {q_cpu, k_cpu, v_cpu, k_cache_cpu, v_cache_cpu} =
+        Nx.with_default_backend(Nx.BinaryBackend, fn ->
+          {
+            Nx.iota({1, 2, 4, 4}, type: :f32) |> Nx.add(1) |> Nx.divide(100),
+            Nx.iota({1, 2, 2, 4}, type: :f32) |> Nx.add(11) |> Nx.divide(110),
+            Nx.iota({1, 2, 2, 4}, type: :f32) |> Nx.add(17) |> Nx.divide(120),
+            Nx.iota({1, 2, 5, 4}, type: :f32) |> Nx.divide(1_000),
+            Nx.iota({1, 2, 5, 4}, type: :f32) |> Nx.add(50) |> Nx.divide(1_000)
+          }
+        end)
+
+      offset = 1
+      head_dim = 4
+      theta = 10_000.0
+      scale = 1.0 / :math.sqrt(head_dim)
+
+      {attn_ref, k_ref, v_ref} =
+        EMLX.qwen3_kv_cache_attention(
+          EMLX.Backend.from_nx(gpu(q_cpu)),
+          EMLX.Backend.from_nx(gpu(k_cpu)),
+          EMLX.Backend.from_nx(gpu(v_cpu)),
+          EMLX.Backend.from_nx(gpu(k_cache_cpu)),
+          EMLX.Backend.from_nx(gpu(v_cache_cpu)),
+          offset,
+          scale,
+          head_dim,
+          theta
+        )
+
+      {expected_attn, expected_k, expected_v} =
+        qwen3_kv_cache_attention_reference(
+          q_cpu,
+          k_cpu,
+          v_cpu,
+          k_cache_cpu,
+          v_cache_cpu,
+          offset,
+          scale,
+          head_dim,
+          theta
+        )
+
+      assert_all_close(
+        attn_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_attn,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        k_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_k,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        v_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_v,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+    end
+
+    test "matches pure Nx reference for batched GQA prefill with nonzero offset" do
+      {q_cpu, k_cpu, v_cpu, k_cache_cpu, v_cache_cpu} =
+        Nx.with_default_backend(Nx.BinaryBackend, fn ->
+          {
+            Nx.iota({2, 2, 4, 4}, type: :f32) |> Nx.add(3) |> Nx.divide(100),
+            Nx.iota({2, 2, 2, 4}, type: :f32) |> Nx.add(23) |> Nx.divide(130),
+            Nx.iota({2, 2, 2, 4}, type: :f32) |> Nx.add(37) |> Nx.divide(140),
+            Nx.iota({2, 2, 6, 4}, type: :f32) |> Nx.add(5) |> Nx.divide(1_000),
+            Nx.iota({2, 2, 6, 4}, type: :f32) |> Nx.add(95) |> Nx.divide(1_000)
+          }
+        end)
+
+      offset = 2
+      head_dim = 4
+      theta = 10_000.0
+      scale = 1.0 / :math.sqrt(head_dim)
+
+      {attn_ref, k_ref, v_ref} =
+        EMLX.qwen3_kv_cache_attention(
+          EMLX.Backend.from_nx(gpu(q_cpu)),
+          EMLX.Backend.from_nx(gpu(k_cpu)),
+          EMLX.Backend.from_nx(gpu(v_cpu)),
+          EMLX.Backend.from_nx(gpu(k_cache_cpu)),
+          EMLX.Backend.from_nx(gpu(v_cache_cpu)),
+          offset,
+          scale,
+          head_dim,
+          theta
+        )
+
+      {expected_attn, expected_k, expected_v} =
+        qwen3_kv_cache_attention_reference(
+          q_cpu,
+          k_cpu,
+          v_cpu,
+          k_cache_cpu,
+          v_cache_cpu,
+          offset,
+          scale,
+          head_dim,
+          theta
+        )
+
+      assert Nx.shape(expected_attn) == {2, 2, 16}
+
+      assert_all_close(
+        attn_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_attn,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        k_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_k,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        v_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_v,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+    end
+  end
+
+  describe "dense Qwen3 native helpers" do
+    test "qwen3_mlp matches pure Nx reference" do
+      {hidden_cpu, norm_cpu, gate_cpu, up_cpu, down_cpu} =
+        Nx.with_default_backend(Nx.BinaryBackend, fn ->
+          {
+            Nx.iota({1, 2, 4}, type: :f32) |> Nx.add(1) |> Nx.divide(10),
+            Nx.tensor([1.0, 1.1, 0.9, 1.2], type: :f32),
+            Nx.iota({4, 6}, type: :f32) |> Nx.add(1) |> Nx.divide(50),
+            Nx.iota({4, 6}, type: :f32) |> Nx.add(7) |> Nx.divide(60),
+            Nx.iota({6, 4}, type: :f32) |> Nx.add(3) |> Nx.divide(70)
+          }
+        end)
+
+      eps = 1.0e-6
+
+      out_ref =
+        EMLX.qwen3_mlp(
+          EMLX.Backend.from_nx(gpu(hidden_cpu)),
+          EMLX.Backend.from_nx(gpu(norm_cpu)),
+          EMLX.Backend.from_nx(gpu(gate_cpu)),
+          EMLX.Backend.from_nx(gpu(up_cpu)),
+          EMLX.Backend.from_nx(gpu(down_cpu)),
+          eps
+        )
+
+      expected = qwen3_mlp_reference(hidden_cpu, norm_cpu, gate_cpu, up_cpu, down_cpu, eps)
+
+      assert_all_close(
+        out_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+    end
+
+    test "qwen3_attention_block matches pure Nx reference" do
+      fixtures = qwen3_dense_attention_fixtures()
+      scale = 1.0 / :math.sqrt(fixtures.head_dim)
+
+      {out_ref, k_ref, v_ref} =
+        EMLX.qwen3_attention_block(
+          EMLX.Backend.from_nx(gpu(fixtures.hidden)),
+          EMLX.Backend.from_nx(gpu(fixtures.norm1)),
+          EMLX.Backend.from_nx(gpu(fixtures.q_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.v_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.o_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.q_norm)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_norm)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_cache)),
+          EMLX.Backend.from_nx(gpu(fixtures.v_cache)),
+          fixtures.offset,
+          scale,
+          fixtures.head_dim,
+          fixtures.theta,
+          fixtures.eps
+        )
+
+      {expected, expected_k, expected_v} = qwen3_attention_block_reference(fixtures)
+
+      assert_all_close(
+        out_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        k_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_k,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        v_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_v,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+    end
+
+    test "qwen3_attention_block matches pure Nx reference for batched GQA" do
+      fixtures = qwen3_batched_dense_attention_fixtures()
+      scale = 1.0 / :math.sqrt(fixtures.head_dim)
+
+      {out_ref, k_ref, v_ref} =
+        EMLX.qwen3_attention_block(
+          EMLX.Backend.from_nx(gpu(fixtures.hidden)),
+          EMLX.Backend.from_nx(gpu(fixtures.norm1)),
+          EMLX.Backend.from_nx(gpu(fixtures.q_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.v_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.o_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.q_norm)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_norm)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_cache)),
+          EMLX.Backend.from_nx(gpu(fixtures.v_cache)),
+          fixtures.offset,
+          scale,
+          fixtures.head_dim,
+          fixtures.theta,
+          fixtures.eps
+        )
+
+      {expected, expected_k, expected_v} = qwen3_attention_block_reference(fixtures)
+
+      assert Nx.shape(expected) == {2, 2, 4}
+
+      assert_all_close(
+        out_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        k_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_k,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        v_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_v,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+    end
+
+    test "qwen3_layer matches pure Nx reference" do
+      fixtures = qwen3_dense_attention_fixtures()
+      scale = 1.0 / :math.sqrt(fixtures.head_dim)
+
+      {out_ref, k_ref, v_ref} =
+        EMLX.qwen3_layer(
+          EMLX.Backend.from_nx(gpu(fixtures.hidden)),
+          EMLX.Backend.from_nx(gpu(fixtures.norm1)),
+          EMLX.Backend.from_nx(gpu(fixtures.q_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.v_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.o_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.q_norm)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_norm)),
+          EMLX.Backend.from_nx(gpu(fixtures.k_cache)),
+          EMLX.Backend.from_nx(gpu(fixtures.v_cache)),
+          EMLX.Backend.from_nx(gpu(fixtures.norm2)),
+          EMLX.Backend.from_nx(gpu(fixtures.gate_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.up_proj)),
+          EMLX.Backend.from_nx(gpu(fixtures.down_proj)),
+          fixtures.offset,
+          scale,
+          fixtures.head_dim,
+          fixtures.theta,
+          fixtures.eps
+        )
+
+      {attn_expected, expected_k, expected_v} = qwen3_attention_block_reference(fixtures)
+
+      expected =
+        qwen3_mlp_reference(
+          attn_expected,
+          fixtures.norm2,
+          fixtures.gate_proj,
+          fixtures.up_proj,
+          fixtures.down_proj,
+          fixtures.eps
+        )
+
+      assert_all_close(
+        out_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        k_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_k,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+
+      assert_all_close(
+        v_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected_v,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+    end
+
+    test "qwen3_attention_residual matches pure Nx reference" do
+      {hidden, attn_out, o_proj} =
+        Nx.with_default_backend(Nx.BinaryBackend, fn ->
+          {
+            Nx.iota({1, 2, 4}, type: :f32) |> Nx.add(1) |> Nx.divide(10),
+            Nx.iota({1, 2, 3}, type: :f32) |> Nx.add(5) |> Nx.divide(20),
+            Nx.iota({3, 4}, type: :f32) |> Nx.add(3) |> Nx.divide(30)
+          }
+        end)
+
+      out_ref =
+        EMLX.qwen3_attention_residual(
+          EMLX.Backend.from_nx(gpu(hidden)),
+          EMLX.Backend.from_nx(gpu(attn_out)),
+          EMLX.Backend.from_nx(gpu(o_proj))
+        )
+
+      expected =
+        hidden
+        |> Nx.add(Nx.dot(attn_out, [2], o_proj, [0]))
+        |> Nx.backend_transfer(Nx.BinaryBackend)
+
+      assert_all_close(
+        out_ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend),
+        expected,
+        atol: 1.0e-5,
+        rtol: 1.0e-5
+      )
+    end
+  end
+
+  describe "EMLX.qwen3_attention_block/15 validation" do
+    test "qwen3_kv_cache_attention rejects required cache length overflow before graph construction" do
+      q = Nx.broadcast(0.0, {1, 1, 2, 2}) |> Nx.as_type(:f32) |> gpu()
+      k = Nx.broadcast(0.0, {1, 1, 1, 2}) |> Nx.as_type(:f32) |> gpu()
+      v = Nx.broadcast(0.0, {1, 1, 1, 2}) |> Nx.as_type(:f32) |> gpu()
+      k_cache = Nx.broadcast(0.0, {1, 1, 4, 2}) |> Nx.as_type(:f32) |> gpu()
+      v_cache = Nx.broadcast(0.0, {1, 1, 4, 2}) |> Nx.as_type(:f32) |> gpu()
+
+      assert_raise EMLX.NIFError,
+                   ~r/KV cache capacity 4 is smaller than required length 2147483648/,
+                   fn ->
+                     EMLX.qwen3_kv_cache_attention(
+                       EMLX.Backend.from_nx(q),
+                       EMLX.Backend.from_nx(k),
+                       EMLX.Backend.from_nx(v),
+                       EMLX.Backend.from_nx(k_cache),
+                       EMLX.Backend.from_nx(v_cache),
+                       2_147_483_647,
+                       1.0 / :math.sqrt(2),
+                       2,
+                       10_000.0
+                     )
+                   end
+    end
+
+    test "qwen3_layer rejects required cache length overflow before graph construction" do
+      fixtures = qwen3_dense_attention_fixtures()
+
+      assert_raise EMLX.NIFError,
+                   ~r/KV cache capacity 4 is smaller than required length 2147483649/,
+                   fn ->
+                     EMLX.qwen3_layer(
+                       EMLX.Backend.from_nx(gpu(fixtures.hidden)),
+                       EMLX.Backend.from_nx(gpu(fixtures.norm1)),
+                       EMLX.Backend.from_nx(gpu(fixtures.q_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.k_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.v_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.o_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.q_norm)),
+                       EMLX.Backend.from_nx(gpu(fixtures.k_norm)),
+                       EMLX.Backend.from_nx(gpu(fixtures.k_cache)),
+                       EMLX.Backend.from_nx(gpu(fixtures.v_cache)),
+                       EMLX.Backend.from_nx(gpu(fixtures.norm2)),
+                       EMLX.Backend.from_nx(gpu(fixtures.gate_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.up_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.down_proj)),
+                       2_147_483_647,
+                       1.0 / :math.sqrt(fixtures.head_dim),
+                       fixtures.head_dim,
+                       fixtures.theta,
+                       fixtures.eps
+                     )
+                   end
+    end
+
+    test "qwen3_attention_block rejects required cache length overflow before graph construction" do
+      fixtures = qwen3_dense_attention_fixtures()
+
+      assert_raise EMLX.NIFError,
+                   ~r/KV cache capacity 4 is smaller than required length 2147483649/,
+                   fn ->
+                     EMLX.qwen3_attention_block(
+                       EMLX.Backend.from_nx(gpu(fixtures.hidden)),
+                       EMLX.Backend.from_nx(gpu(fixtures.norm1)),
+                       EMLX.Backend.from_nx(gpu(fixtures.q_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.k_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.v_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.o_proj)),
+                       EMLX.Backend.from_nx(gpu(fixtures.q_norm)),
+                       EMLX.Backend.from_nx(gpu(fixtures.k_norm)),
+                       EMLX.Backend.from_nx(gpu(fixtures.k_cache)),
+                       EMLX.Backend.from_nx(gpu(fixtures.v_cache)),
+                       2_147_483_647,
+                       1.0 / :math.sqrt(fixtures.head_dim),
+                       fixtures.head_dim,
+                       fixtures.theta,
+                       fixtures.eps
+                     )
+                   end
+    end
+
+    test "rejects projection widths before deriving head counts" do
+      hidden = Nx.broadcast(0.0, {1, 1, 4}) |> Nx.as_type(:f16) |> gpu()
+      norm = Nx.broadcast(1.0, {4}) |> Nx.as_type(:f16) |> gpu()
+      q_proj = Nx.broadcast(0.1, {4, 4}) |> Nx.as_type(:f16) |> gpu()
+      k_proj = Nx.broadcast(0.1, {4, 1}) |> Nx.as_type(:f16) |> gpu()
+      v_proj = Nx.broadcast(0.1, {4, 1}) |> Nx.as_type(:f16) |> gpu()
+      o_proj = Nx.broadcast(0.1, {4, 4}) |> Nx.as_type(:f16) |> gpu()
+      q_norm = Nx.broadcast(1.0, {2}) |> Nx.as_type(:f16) |> gpu()
+      k_norm = Nx.broadcast(1.0, {2}) |> Nx.as_type(:f16) |> gpu()
+      k_cache = Nx.broadcast(0.0, {1, 1, 4, 2}) |> Nx.as_type(:f16) |> gpu()
+      v_cache = Nx.broadcast(0.0, {1, 1, 4, 2}) |> Nx.as_type(:f16) |> gpu()
+
+      assert_raise EMLX.NIFError,
+                   ~r/projection output widths must be divisible by head_dim/,
+                   fn ->
+                     EMLX.qwen3_attention_block(
+                       EMLX.Backend.from_nx(hidden),
+                       EMLX.Backend.from_nx(norm),
+                       EMLX.Backend.from_nx(q_proj),
+                       EMLX.Backend.from_nx(k_proj),
+                       EMLX.Backend.from_nx(v_proj),
+                       EMLX.Backend.from_nx(o_proj),
+                       EMLX.Backend.from_nx(q_norm),
+                       EMLX.Backend.from_nx(k_norm),
+                       EMLX.Backend.from_nx(k_cache),
+                       EMLX.Backend.from_nx(v_cache),
+                       0,
+                       1.0 / :math.sqrt(2),
+                       2,
+                       10_000.0,
+                       1.0e-6
+                     )
+                   end
+    end
+  end
+
+  defp qwen3_dense_attention_fixtures do
+    Nx.with_default_backend(Nx.BinaryBackend, fn ->
+      %{
+        hidden: Nx.iota({1, 2, 4}, type: :f32) |> Nx.add(1) |> Nx.divide(10),
+        norm1: Nx.tensor([1.0, 1.1, 0.9, 1.2], type: :f32),
+        norm2: Nx.tensor([0.9, 1.0, 1.1, 1.2], type: :f32),
+        q_norm: Nx.tensor([1.0, 1.1], type: :f32),
+        k_norm: Nx.tensor([0.9, 1.2], type: :f32),
+        q_proj: Nx.iota({4, 4}, type: :f32) |> Nx.add(1) |> Nx.divide(50),
+        k_proj: Nx.iota({4, 2}, type: :f32) |> Nx.add(2) |> Nx.divide(60),
+        v_proj: Nx.iota({4, 2}, type: :f32) |> Nx.add(3) |> Nx.divide(70),
+        o_proj: Nx.iota({4, 4}, type: :f32) |> Nx.add(4) |> Nx.divide(80),
+        gate_proj: Nx.iota({4, 6}, type: :f32) |> Nx.add(1) |> Nx.divide(50),
+        up_proj: Nx.iota({4, 6}, type: :f32) |> Nx.add(7) |> Nx.divide(60),
+        down_proj: Nx.iota({6, 4}, type: :f32) |> Nx.add(3) |> Nx.divide(70),
+        k_cache: Nx.broadcast(0.0, {1, 1, 4, 2}) |> Nx.as_type(:f32),
+        v_cache: Nx.broadcast(0.0, {1, 1, 4, 2}) |> Nx.as_type(:f32),
+        offset: 0,
+        head_dim: 2,
+        theta: 10_000.0,
+        eps: 1.0e-6
+      }
+    end)
+  end
+
+  defp qwen3_batched_dense_attention_fixtures do
+    Nx.with_default_backend(Nx.BinaryBackend, fn ->
+      %{
+        hidden: Nx.iota({2, 2, 4}, type: :f32) |> Nx.add(1) |> Nx.divide(20),
+        norm1: Nx.tensor([1.0, 1.1, 0.9, 1.2], type: :f32),
+        q_norm: Nx.tensor([1.0, 1.1], type: :f32),
+        k_norm: Nx.tensor([0.9, 1.2], type: :f32),
+        q_proj: Nx.iota({4, 8}, type: :f32) |> Nx.add(1) |> Nx.divide(80),
+        k_proj: Nx.iota({4, 4}, type: :f32) |> Nx.add(3) |> Nx.divide(90),
+        v_proj: Nx.iota({4, 4}, type: :f32) |> Nx.add(5) |> Nx.divide(100),
+        o_proj: Nx.iota({8, 4}, type: :f32) |> Nx.add(7) |> Nx.divide(110),
+        k_cache: Nx.iota({2, 2, 6, 2}, type: :f32) |> Nx.add(11) |> Nx.divide(1_000),
+        v_cache: Nx.iota({2, 2, 6, 2}, type: :f32) |> Nx.add(101) |> Nx.divide(1_000),
+        offset: 2,
+        head_dim: 2,
+        theta: 10_000.0,
+        eps: 1.0e-6
+      }
+    end)
+  end
+
+  defp qwen3_kv_cache_attention_reference(
+         q,
+         new_k,
+         new_v,
+         k_cache,
+         v_cache,
+         offset,
+         scale,
+         head_dim,
+         theta
+       ) do
+    {batch, seq_len, q_heads, _head_dim} = Nx.shape(q)
+    {_batch, _seq_len, kv_heads, _head_dim} = Nx.shape(new_k)
+
+    q_bn =
+      q
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> qwen3_rope_reference(head_dim, theta, offset)
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    k_bn =
+      new_k
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> qwen3_rope_reference(head_dim, theta, offset)
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    v_bn = new_v |> Nx.transpose(axes: [0, 2, 1, 3]) |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    k_cache = Nx.put_slice(k_cache, [0, 0, offset, 0], k_bn)
+    v_cache = Nx.put_slice(v_cache, [0, 0, offset, 0], v_bn)
+
+    valid_len = offset + seq_len
+    k_valid = Nx.slice_along_axis(k_cache, 0, valid_len, axis: 2)
+    v_valid = Nx.slice_along_axis(v_cache, 0, valid_len, axis: 2)
+
+    groups = div(q_heads, kv_heads)
+    k_repeated = repeat_kv_heads_bn(k_valid, groups)
+    v_repeated = repeat_kv_heads_bn(v_valid, groups)
+
+    scores =
+      q_bn
+      |> Nx.new_axis(3)
+      |> Nx.multiply(Nx.new_axis(k_repeated, 2))
+      |> Nx.sum(axes: [4])
+      |> Nx.multiply(scale)
+      |> apply_causal_mask(offset, seq_len, valid_len)
+
+    weights = softmax_reference(scores, 3)
+
+    attn =
+      weights
+      |> Nx.new_axis(4)
+      |> Nx.multiply(Nx.new_axis(v_repeated, 2))
+      |> Nx.sum(axes: [3])
+
+    attn_out =
+      attn
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> Nx.reshape({batch, seq_len, q_heads * head_dim})
+
+    {attn_out, k_cache, v_cache}
+  end
+
+  defp qwen3_mlp_reference(hidden, norm, gate_proj, up_proj, down_proj, eps) do
+    xn = rms_norm_reference(hidden, norm, eps)
+    gate = Nx.dot(xn, [2], gate_proj, [0])
+    up = Nx.dot(xn, [2], up_proj, [0])
+    mlp = Nx.multiply(Nx.multiply(gate, Nx.sigmoid(gate)), up)
+    out = Nx.dot(mlp, [2], down_proj, [0])
+    Nx.add(hidden, out)
+  end
+
+  defp qwen3_attention_block_reference(fixtures) do
+    hidden = fixtures.hidden
+    offset = fixtures.offset
+    head_dim = fixtures.head_dim
+    scale = 1.0 / :math.sqrt(head_dim)
+
+    {batch, seq_len, _hidden_size} = Nx.shape(hidden)
+
+    xn = rms_norm_reference(hidden, fixtures.norm1, fixtures.eps)
+
+    q_flat = Nx.dot(xn, [2], fixtures.q_proj, [0])
+    k_flat = Nx.dot(xn, [2], fixtures.k_proj, [0])
+    v_flat = Nx.dot(xn, [2], fixtures.v_proj, [0])
+
+    q_heads = div(elem(Nx.shape(fixtures.q_proj), 1), head_dim)
+    kv_heads = div(elem(Nx.shape(fixtures.k_proj), 1), head_dim)
+
+    q = Nx.reshape(q_flat, {batch, seq_len, q_heads, head_dim})
+    k = Nx.reshape(k_flat, {batch, seq_len, kv_heads, head_dim})
+    v = Nx.reshape(v_flat, {batch, seq_len, kv_heads, head_dim})
+
+    q = rms_norm_reference(q, fixtures.q_norm, fixtures.eps)
+    k = rms_norm_reference(k, fixtures.k_norm, fixtures.eps)
+
+    q_bn =
+      q
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> qwen3_rope_reference(head_dim, fixtures.theta, offset)
+
+    k_bn =
+      k
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> qwen3_rope_reference(head_dim, fixtures.theta, offset)
+
+    q_bn = Nx.backend_transfer(q_bn, Nx.BinaryBackend)
+    k_bn = Nx.backend_transfer(k_bn, Nx.BinaryBackend)
+    v_bn = v |> Nx.transpose(axes: [0, 2, 1, 3]) |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    k_cache = Nx.put_slice(fixtures.k_cache, [0, 0, offset, 0], k_bn)
+    v_cache = Nx.put_slice(fixtures.v_cache, [0, 0, offset, 0], v_bn)
+
+    valid_len = offset + seq_len
+    k_valid = Nx.slice_along_axis(k_cache, 0, valid_len, axis: 2)
+    v_valid = Nx.slice_along_axis(v_cache, 0, valid_len, axis: 2)
+
+    groups = div(q_heads, kv_heads)
+    k_repeated = repeat_kv_heads_bn(k_valid, groups)
+    v_repeated = repeat_kv_heads_bn(v_valid, groups)
+
+    scores =
+      q_bn
+      |> Nx.new_axis(3)
+      |> Nx.multiply(Nx.new_axis(k_repeated, 2))
+      |> Nx.sum(axes: [4])
+      |> Nx.multiply(scale)
+
+    scores = apply_causal_mask(scores, offset, seq_len, valid_len)
+    weights = softmax_reference(scores, 3)
+
+    attn =
+      weights
+      |> Nx.new_axis(4)
+      |> Nx.multiply(Nx.new_axis(v_repeated, 2))
+      |> Nx.sum(axes: [3])
+
+    attn_out =
+      attn
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> Nx.reshape({batch, seq_len, q_heads * head_dim})
+
+    projected = Nx.dot(attn_out, [2], fixtures.o_proj, [0])
+
+    {Nx.add(hidden, projected), k_cache, v_cache}
+  end
+
+  defp rms_norm_reference(tensor, weight, eps) do
+    tensor
+    |> Nx.pow(2)
+    |> Nx.mean(axes: [-1], keep_axes: true)
+    |> Nx.add(eps)
+    |> Nx.sqrt()
+    |> then(&Nx.divide(tensor, &1))
+    |> Nx.multiply(weight)
+  end
+
+  defp qwen3_rope_reference(tensor, dims, theta, offset) do
+    {_batch, _heads, seq_len, _dims} = Nx.shape(tensor)
+    half = div(dims, 2)
+
+    inv_freq =
+      Nx.iota({half}, type: :f32)
+      |> Nx.multiply(2)
+      |> Nx.divide(dims)
+      |> then(&Nx.pow(theta, &1))
+      |> then(&Nx.divide(1.0, &1))
+
+    positions =
+      Nx.iota({seq_len}, type: :f32)
+      |> Nx.add(offset)
+      |> Nx.reshape({seq_len, 1})
+
+    freqs = Nx.multiply(positions, Nx.reshape(inv_freq, {1, half}))
+
+    cos =
+      Nx.concatenate([Nx.cos(freqs), Nx.cos(freqs)], axis: 1)
+      |> Nx.reshape({1, 1, seq_len, dims})
+
+    sin =
+      Nx.concatenate([Nx.sin(freqs), Nx.sin(freqs)], axis: 1)
+      |> Nx.reshape({1, 1, seq_len, dims})
+
+    first = tensor[[.., .., .., 0..(half - 1)//1]]
+    second = tensor[[.., .., .., half..(dims - 1)//1]]
+    rotated = Nx.concatenate([Nx.negate(second), first], axis: 3)
+
+    Nx.add(Nx.multiply(tensor, cos), Nx.multiply(rotated, sin))
+  end
+
+  defp repeat_kv_heads_bn(tensor, 1), do: tensor
+
+  defp repeat_kv_heads_bn(tensor, groups) do
+    {batch, n_kv, t_kv, head_dim} = Nx.shape(tensor)
+
+    tensor
+    |> Nx.new_axis(2)
+    |> Nx.broadcast({batch, n_kv, groups, t_kv, head_dim})
+    |> Nx.reshape({batch, n_kv * groups, t_kv, head_dim})
+  end
+
+  defp apply_causal_mask(scores, offset, seq_len, valid_len) do
+    query_positions =
+      Nx.iota({seq_len}, type: :s32, backend: Nx.BinaryBackend)
+      |> Nx.add(offset)
+      |> Nx.reshape({1, 1, seq_len, 1})
+
+    key_positions =
+      Nx.iota({valid_len}, type: :s32, backend: Nx.BinaryBackend)
+      |> Nx.reshape({1, 1, 1, valid_len})
+
+    mask =
+      key_positions
+      |> Nx.less_equal(query_positions)
+      |> Nx.broadcast(Nx.shape(scores))
+
+    Nx.select(mask, scores, Nx.broadcast(-1.0e9, Nx.shape(scores)))
+  end
+
+  defp softmax_reference(tensor, axis) do
+    shifted = Nx.subtract(tensor, Nx.reduce_max(tensor, axes: [axis], keep_axes: true))
+    exp = Nx.exp(shifted)
+    Nx.divide(exp, Nx.sum(exp, axes: [axis], keep_axes: true))
+  end
+
+  defp causal_kv_attention_reference(q, new_k, new_v, k_cache, v_cache, offset, scale, key_mask) do
+    q = Nx.backend_transfer(q, Nx.BinaryBackend)
+    new_k = Nx.backend_transfer(new_k, Nx.BinaryBackend)
+    new_v = Nx.backend_transfer(new_v, Nx.BinaryBackend)
+    k_cache = Nx.backend_transfer(k_cache, Nx.BinaryBackend)
+    v_cache = Nx.backend_transfer(v_cache, Nx.BinaryBackend)
+    key_mask = Nx.backend_transfer(key_mask, Nx.BinaryBackend)
+
+    {_batch, t_q, n_q, _head_dim} = Nx.shape(q)
+    {_batch, t_new, n_kv, _head_dim} = Nx.shape(new_k)
+    t_kv = offset + t_new
+
+    k_cache = Nx.put_slice(k_cache, [0, offset, 0, 0], new_k)
+    v_cache = Nx.put_slice(v_cache, [0, offset, 0, 0], new_v)
+
+    k_valid = Nx.slice_along_axis(k_cache, 0, t_kv, axis: 1)
+    v_valid = Nx.slice_along_axis(v_cache, 0, t_kv, axis: 1)
+
+    q_heads = Nx.transpose(q, axes: [0, 2, 1, 3])
+    k_heads = k_valid |> Nx.transpose(axes: [0, 2, 1, 3]) |> repeat_kv_heads(div(n_q, n_kv))
+    v_heads = v_valid |> Nx.transpose(axes: [0, 2, 1, 3]) |> repeat_kv_heads(div(n_q, n_kv))
+
+    scores =
+      q_heads
+      |> Nx.new_axis(3)
+      |> Nx.multiply(Nx.new_axis(k_heads, 2))
+      |> Nx.sum(axes: [4])
+      |> Nx.multiply(scale)
+
+    query_positions =
+      Nx.iota({t_q}, type: :s32, backend: Nx.BinaryBackend)
+      |> Nx.add(offset)
+      |> Nx.reshape({1, 1, t_q, 1})
+
+    key_positions =
+      Nx.iota({t_kv}, type: :s32, backend: Nx.BinaryBackend)
+      |> Nx.reshape({1, 1, 1, t_kv})
+
+    causal_mask = Nx.less_equal(key_positions, query_positions)
+
+    valid_mask =
+      key_mask
+      |> Nx.equal(1)
+      |> Nx.reshape({elem(Nx.shape(key_mask), 0), 1, 1, t_kv})
+
+    mask =
+      causal_mask
+      |> Nx.logical_and(valid_mask)
+      |> Nx.broadcast(Nx.shape(scores))
+
+    scores = Nx.select(mask, scores, Nx.broadcast(-1.0e9, Nx.shape(scores)))
+
+    probs =
+      scores
+      |> Nx.subtract(Nx.reduce_max(scores, axes: [3], keep_axes: true))
+      |> Nx.exp()
+
+    probs = Nx.divide(probs, Nx.sum(probs, axes: [3], keep_axes: true))
+
+    probs
+    |> Nx.new_axis(4)
+    |> Nx.multiply(Nx.new_axis(v_heads, 2))
+    |> Nx.sum(axes: [3])
+    |> Nx.transpose(axes: [0, 2, 1, 3])
+  end
+
+  defp repeat_kv_heads(kv, 1), do: kv
+
+  defp repeat_kv_heads(kv, groups) do
+    {batch, n_kv, t_kv, head_dim} = Nx.shape(kv)
+
+    kv
+    |> Nx.new_axis(2)
+    |> Nx.broadcast({batch, n_kv, groups, t_kv, head_dim})
+    |> Nx.reshape({batch, n_kv * groups, t_kv, head_dim})
+  end
 end


### PR DESCRIPTION
This adds native MLX-backed primitives for dense Qwen3 layer execution.

The main goal is to make the Qwen3 attention/MLP/layer pieces available as
tested EMLX primitives before adding higher-level EMLXAxon loading or text
generation code on top.

This includes:

- Qwen3 RoPE + KV cache attention
- dense Qwen3 MLP
- dense attention residual projection
- dense attention block
- dense transformer layer

The dense projection layout is `{in, out}`, so the native path can use direct
`matmul(input, weight)` calls. The Qwen3-specific KV cache helpers use
`{B, N_kv, T_max, D}` caches.

I kept this PR limited to the lower-level EMLX side. It does not add
safetensors loading or a text generation API; those are easier to review as
follow-up changes once the primitives are in place.

Tests cover numerical comparisons against pure Nx references for:

- GQA KV attention
- Qwen3 MLP
- attention residual projection
- attention block
- full transformer layer

There is also coverage for nonzero cache offsets, batch size 2, cache updates,
projection shape validation, and cache-length overflow before graph
construction.

Tests:

- `mix test test/emlx/fast_test.exs --include metal`
