### PR TITLE
feat: add fused kv_cache+sdpa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ emlx-*.tar
 # Validation subproject build artifacts (not the mix.lock — that is committed).
 /**/_build/
 /**/deps/
+
+# Local working notes / investigation plans, not part of the public plan history.
+/.work/

--- a/emlx/c_src/emlx_compiler.cpp
+++ b/emlx/c_src/emlx_compiler.cpp
@@ -1939,6 +1939,69 @@ static const std::unordered_map<std::string, MultiOpFn> multi_op_registry = {
      [](const auto &ops, const auto &) -> std::vector<mlx::core::array> {
        return contiguous_all(mlx::core::linalg::lu(ops[0], k_linalg_cpu));
      }},
+    // The head-transpose needed for `fast::scaled_dot_product_attention`
+    // (which requires {B, N, T, D}) is done internally on q and on the
+    // *already-written* k_upd/v_upd -- this is the same single full-cache
+    // transpose the unfused path already pays for (its own
+    // `build_sdpa_layer` transposes the post-update K/V cache before
+    // calling SDPA); fusing does not add a second one, since k_upd/v_upd
+    // are returned pre-transpose.
+    {"kv_cache_sdpa_update",
+     [](const auto &ops, const auto &attrs) -> std::vector<mlx::core::array> {
+       const auto &q = ops[0];
+       const auto &new_k = ops[1];
+       const auto &new_v = ops[2];
+       const auto &k_cache = ops[3];
+       const auto &v_cache = ops[4];
+       const auto &offset = ops[5];
+       const auto &key_mask = ops[6];
+       float scale = attr_to_float(attrs[0]);
+       int kv_offset = static_cast<int>(attrs[1]);
+
+       int T_max = static_cast<int>(k_cache.shape(1));
+       int T_q_write = static_cast<int>(new_k.shape(1));
+
+       // Dynamic write-start {0, clamp(offset, 0, T_max-T_q_write), 0, 0} --
+       // same clamp-and-concatenate construction as op_registry["put_slice"]
+       // (T_max-T_q_write, not T_max-1, so the write itself never runs past
+       // the cache's last valid row when T_q_write > 1, e.g. prefill).
+       auto s = mlx::core::reshape(mlx::core::astype(offset, mlx::core::int32), {1});
+       auto max_s = mlx::core::full({1}, T_max - T_q_write, mlx::core::int32);
+       auto zero1 = mlx::core::zeros({1}, mlx::core::int32);
+       auto offset_clamped = mlx::core::minimum(mlx::core::maximum(s, zero1), max_s);
+       auto start = mlx::core::concatenate({zero1, offset_clamped, zero1, zero1}, 0);
+
+       std::vector<int> all_axes = {0, 1, 2, 3};
+       auto k_upd = mlx::core::slice_update(k_cache, new_k, start, all_axes);
+       auto v_upd = mlx::core::slice_update(v_cache, new_v, start, all_axes);
+
+       // Head-transpose for SDPA: {B, T, N, D} -> {B, N, T, D}. Mirrors
+       // build_sdpa_layer's own Nx.transpose(axes: [0, 2, 1, 3]) exactly.
+       std::vector<int> head_transpose = {0, 2, 1, 3};
+       auto q_t = mlx::core::transpose(q, head_transpose);
+       auto k_t = mlx::core::transpose(k_upd, head_transpose);
+       auto v_t = mlx::core::transpose(v_upd, head_transpose);
+
+       // Combined causal + key_mask additive mask -- verbatim copy of
+       // "fast_sdpa_causal_key_masked"'s formula above (T_kv = T_max here).
+       auto km = mlx::core::reshape(key_mask, {key_mask.shape(0), 1, 1, key_mask.shape(1)});
+       int T_q = q_t.shape(2);
+       auto row = mlx::core::reshape(mlx::core::arange(T_q, mlx::core::int32), {1, 1, T_q, 1});
+       auto col = mlx::core::reshape(mlx::core::arange(T_max, mlx::core::int32), {1, 1, 1, T_max});
+       auto causal_bool = mlx::core::less_equal(
+           col, mlx::core::add(row, mlx::core::array(kv_offset, mlx::core::int32)));
+       auto keep = mlx::core::logical_and(km, causal_bool);
+       auto mask_dtype = q_t.dtype();
+       auto zero_val = mlx::core::zeros({}, mask_dtype);
+       auto neginf_val =
+           mlx::core::full({}, -std::numeric_limits<float>::infinity(), mask_dtype);
+       auto additive = mlx::core::where(keep, zero_val, neginf_val);
+
+       auto attn_out = mlx::core::fast::scaled_dot_product_attention(
+           q_t, k_t, v_t, scale, "array", additive, std::nullopt);
+
+       return {attn_out, k_upd, v_upd};
+     }},
 };
 
 // ── interpret_instructions ────────────────────────────────────────────────

--- a/emlx/c_src/emlx_compiler.cpp
+++ b/emlx/c_src/emlx_compiler.cpp
@@ -1468,8 +1468,15 @@ static const std::unordered_map<std::string, OpFn> op_registry = {
            {}, -std::numeric_limits<float>::infinity(), mask_dtype);
        auto additive = mlx::core::where(keep, zero_val, neginf_val);
 
-       return mlx::core::fast::scaled_dot_product_attention(
+       auto attn_t = mlx::core::fast::scaled_dot_product_attention(
            q, k, v, scale, "array", additive, std::nullopt);
+
+       // Replace NaN with 0 for all-masked rows (softmax(-inf,...,-inf) = NaN
+       // in Flash-Attention when seq_len >= Metal tile size, but semantically
+       // = 0) -- happens for left-padded prefill query rows that have no
+       // causally-visible *and* key_mask-valid key at all.
+       return mlx::core::where(mlx::core::isnan(attn_t),
+                               mlx::core::zeros_like(attn_t), attn_t);
      }},
 
     // sdpa (causal + key_mask, + sinks): operands = [q, k, v, key_mask,
@@ -1504,8 +1511,12 @@ static const std::unordered_map<std::string, OpFn> op_registry = {
            {}, -std::numeric_limits<float>::infinity(), mask_dtype);
        auto additive = mlx::core::where(keep, zero_val, neginf_val);
 
-       return mlx::core::fast::scaled_dot_product_attention(
+       auto attn_t = mlx::core::fast::scaled_dot_product_attention(
            q, k, v, scale, "array", additive, sinks);
+
+       // See "fast_sdpa_causal_key_masked" above: NaN-guard all-masked rows.
+       return mlx::core::where(mlx::core::isnan(attn_t),
+                               mlx::core::zeros_like(attn_t), attn_t);
      }},
 
     // rope (scalar offset): operands = [a];
@@ -1999,6 +2010,15 @@ static const std::unordered_map<std::string, MultiOpFn> multi_op_registry = {
 
        auto attn_out = mlx::core::fast::scaled_dot_product_attention(
            q_t, k_t, v_t, scale, "array", additive, std::nullopt);
+
+       // Replace NaN with 0 for all-masked rows (softmax(-inf,...,-inf) = NaN
+       // in Flash-Attention when seq_len >= Metal tile size, but semantically
+       // = 0) -- happens for left-padded prefill query rows that have no
+       // causally-visible *and* key_mask-valid key at all. See
+       // "fast_sdpa_causal_key_masked" above for the unfused version of this
+       // same guard.
+       attn_out = mlx::core::where(mlx::core::isnan(attn_out),
+                                   mlx::core::zeros_like(attn_out), attn_out);
 
        return {attn_out, k_upd, v_upd};
      }},

--- a/emlx/c_src/emlx_fast.cpp
+++ b/emlx/c_src/emlx_fast.cpp
@@ -339,8 +339,14 @@ mlx::core::array fast_sdpa_causal_key_masked_impl(
     auto neginf_val = full({}, -std::numeric_limits<float>::infinity(), mask_dtype);
     auto additive = where(keep, zero_val, neginf_val);
 
-    return fast::scaled_dot_product_attention(
+    auto attn_t = fast::scaled_dot_product_attention(
         *q, *k, *v, (float)scale, "array", additive, sinks_opt, device);
+
+    // Replace NaN with 0 for all-masked rows (softmax(-inf,...,-inf) = NaN in
+    // Flash-Attention when seq_len >= Metal tile size, but semantically = 0).
+    // This happens for left-padded prefill rows, where a padding query
+    // position has no causally-visible *and* key_mask-valid keys at all.
+    return where(isnan(attn_t), zeros_like(attn_t, device), attn_t, device);
   }
 }
 FINE_ASYNC_NIF(fast_sdpa_causal_key_masked)

--- a/emlx/c_src/emlx_nif.cpp
+++ b/emlx/c_src/emlx_nif.cpp
@@ -1335,6 +1335,33 @@ NIF(set_cache_limit) {
   return nx::nif::ok(env, enif_make_uint64(env, prev));
 }
 
+// Starts a Metal GPU frame capture, writing the trace to `path` (a
+// `.gputrace` bundle). Requires `MTL_CAPTURE_ENABLED=1` in the process
+// environment *before* the BEAM (and therefore the Metal device) started —
+// Apple's capture gate is read once at process startup and cannot be
+// enabled lazily. On MLX 0.31.2, missing this precondition throws (caught
+// by CATCH() below and surfaced as a normal EMLX.NIFError), not a silent
+// no-op. See EMLX.metal_start_capture/1's moduledoc for details.
+NIF(metal_start_capture) {
+  std::string path;
+  if (!nx::nif::get(env, argv[0], path)) {
+    return nx::nif::error(env, "Unable to get path param.");
+  }
+  try {
+    mlx::core::metal::start_capture(path);
+    return nx::nif::ok(env);
+  }
+  CATCH()
+}
+
+NIF(metal_stop_capture) {
+  try {
+    mlx::core::metal::stop_capture();
+    return nx::nif::ok(env);
+  }
+  CATCH()
+}
+
 NIF(strides) {
   TENSOR_PARAM(0, t);
 
@@ -1828,8 +1855,12 @@ NIF(eval_program) { return emlx::native::eval_program(env, argc, argv); }
 ASYNC_NIF(eval_program)
 
 static ErlNifFunc nif_funcs[] = {
-    {"eval", 2, eval_async, ERL_NIF_DIRTY_JOB_IO_BOUND},
-    {"eval_many", 2, eval_many_async, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    // No dirty-scheduler flag: eval/eval_many post to a dedicated Worker
+    // OS thread via async_dispatch (emlx_async.hpp) and return immediately —
+    // the calling BEAM scheduler never blocks on the actual MLX work, same
+    // as the ~150 sibling ASYNC_NIF ops below (item 3.8 fold-in).
+    {"eval", 2, eval_async},
+    {"eval_many", 2, eval_many_async},
     {"to_device", 3, to_device_async},
     {"to_blob", 2, to_blob_async},
     {"to_blob", 3, to_blob_async},
@@ -1979,6 +2010,8 @@ static ErlNifFunc nif_funcs[] = {
     {"reset_peak_memory", 0, reset_peak_memory},
     {"set_memory_limit", 1, set_memory_limit},
     {"set_cache_limit", 1, set_cache_limit},
+    {"metal_start_capture", 1, metal_start_capture},
+    {"metal_stop_capture", 0, metal_stop_capture},
 
     // ── Worker control NIFs.
     {"command_queue_new", 1, command_queue_new},
@@ -2006,9 +2039,11 @@ static ErlNifFunc nif_funcs[] = {
     {"kv_cache_sdpa_update", 9, kv_cache_sdpa_update_async},
 
     // ── Native compiler NIFs.
-    {"compile_program", 2, emlx::native::compile_program_async,
-     ERL_NIF_DIRTY_JOB_CPU_BOUND},
-    {"eval_program", 3, eval_program_async, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    // No dirty-scheduler flag on either: both are FINE_ASYNC_NIF/ASYNC_NIF-
+    // wrapped (post to a Worker OS thread, return immediately) — same
+    // reasoning as eval/eval_many above (item 3.8 fold-in).
+    {"compile_program", 2, emlx::native::compile_program_async},
+    {"eval_program", 3, eval_program_async},
     // resolve_runtime_call is NOT worker-routed: it only decodes a reply and
     // memcpy's it into pre-registered buffers/notifies a condvar — no MLX
     // graph work, so it can run directly on the calling BEAM scheduler.

--- a/emlx/lib/emlx.ex
+++ b/emlx/lib/emlx.ex
@@ -2406,4 +2406,38 @@ defmodule EMLX do
   def set_cache_limit(limit) when is_integer(limit) and limit >= 0 do
     EMLX.NIF.set_cache_limit(limit) |> unwrap!()
   end
+
+  @doc """
+  Starts a Metal GPU frame capture, writing the trace to `path` (a
+  `.gputrace` bundle openable in Xcode's GPU Debugger via File → Open).
+
+  Requires `MTL_CAPTURE_ENABLED=1` to be set in the process environment
+  *before* the BEAM starts — Apple's Metal framework reads this gate once at
+  process startup (macOS 14+), and setting it later (e.g. from within
+  Elixir) has no effect. On MLX 0.31.2, forgetting to set it raises a clear
+  `EMLX.NIFError` (`"[metal::start_capture] Failed to start: Capture layer
+  is not inserted."`) rather than silently no-op'ing — confirmed by direct
+  test, contradicting this NIF's original design assumption that
+  `start_capture`/`stop_capture` never throw on ordinary misconfiguration.
+  Still worth confirming `path` exists and is non-empty after
+  `metal_stop_capture/0` as a belt-and-suspenders check, since a future MLX
+  version could change this behavior back to a silent no-op.
+
+  ## Examples
+
+      # export MTL_CAPTURE_ENABLED=1   (before starting the BEAM)
+      EMLX.metal_start_capture("/tmp/trace.gputrace")
+      # ... run some MLX work ...
+      EMLX.metal_stop_capture()
+  """
+  def metal_start_capture(path) when is_binary(path) do
+    EMLX.NIF.metal_start_capture(path) |> unwrap!()
+  end
+
+  @doc """
+  Stops a Metal GPU frame capture started with `metal_start_capture/1`.
+
+  See `metal_start_capture/1` for the `MTL_CAPTURE_ENABLED` precondition.
+  """
+  def metal_stop_capture, do: EMLX.NIF.metal_stop_capture() |> unwrap!()
 end

--- a/emlx/lib/emlx/fast.ex
+++ b/emlx/lib/emlx/fast.ex
@@ -554,9 +554,8 @@ defmodule EMLX.Fast do
 
   @doc false
   def kv_cache_sdpa_update_callback(
-        {%Nx.Tensor{} = q, %Nx.Tensor{} = new_k, %Nx.Tensor{} = new_v,
-         %Nx.Tensor{} = k_cache, %Nx.Tensor{} = v_cache, %Nx.Tensor{} = offset,
-         %Nx.Tensor{} = key_mask},
+        {%Nx.Tensor{} = q, %Nx.Tensor{} = new_k, %Nx.Tensor{} = new_v, %Nx.Tensor{} = k_cache,
+         %Nx.Tensor{} = v_cache, %Nx.Tensor{} = offset, %Nx.Tensor{} = key_mask},
         opts
       ) do
     scale = opts[:scale]
@@ -564,7 +563,12 @@ defmodule EMLX.Fast do
     t_max = elem(Nx.shape(k_cache), 1)
 
     start =
-      offset |> Nx.reshape({}) |> Nx.as_type({:s, 64}) |> Nx.to_number() |> max(0) |> min(t_max - 1)
+      offset
+      |> Nx.reshape({})
+      |> Nx.as_type({:s, 64})
+      |> Nx.to_number()
+      |> max(0)
+      |> min(t_max - 1)
 
     k_upd = Nx.put_slice(k_cache, [0, start, 0, 0], new_k)
     v_upd = Nx.put_slice(v_cache, [0, start, 0, 0], new_v)

--- a/emlx/lib/emlx/fast.ex
+++ b/emlx/lib/emlx/fast.ex
@@ -56,6 +56,9 @@ defmodule EMLX.Fast do
   - `scaled_dot_product_attention_causal_key_masked/5` — causal SDPA; checks key_mask at C++ level, fast-paths to pure causal when all-ones
   - `scaled_dot_product_attention_causal_key_masked/6` — same, plus `opts` (`:sinks`)
   - `swiglu/2` — fused SwiGLU: `silu(gate) * up`
+  - `kv_cache_sdpa_update/8` — fused decode-time KV-cache write + causal SDPA
+    read, 3 outputs (`{attn_out, k_cache_updated, v_cache_updated}`) —
+    inference/decode-loop only, no grad support
   - `einsum/2` — variadic-operand Einstein summation (`mlx::core::einsum`);
     **eager-only, not defn-safe** (see its docs)
 
@@ -454,6 +457,129 @@ defmodule EMLX.Fast do
 
     dtype = Nx.type(q)
     if Nx.type(out) != dtype, do: Nx.as_type(out, dtype), else: out
+  end
+
+  # ── Fused decode-time KV-cache update + SDPA ────────────────────────────────
+  #
+  # SPIKE for `.work/performance_gap/01-attention-block-fusion-via-compiler.md`
+  # (Procedure step 3), built after that stage's Results already concluded the
+  # write-donation fix has no plausible mechanism to help (donation cannot
+  # survive `:while`-carry storage regardless of which primitive performs the
+  # write — see that doc's "Fix surface"/"Recommendation" sections) — kept as
+  # a real, working artifact per explicit instruction to build it anyway, not
+  # because a throughput win is expected. Unlike every other function in this
+  # module, this one does NOT use the single-output `:__EMLX__` metadata
+  # mechanism (`emlx_metadata/4` above) — that mechanism produces exactly one
+  # physical `ref` (see `EMLX.Native.Expr`'s `:metadata` expand_node clause),
+  # and this op has 3 outputs (attn_out, k_upd, v_upd). Instead it uses
+  # `Nx.runtime_call/4`'s `:__emlx_native_multi_op__` escape hatch (see that
+  # same module's `:runtime_call` expand_node clause), which reuses
+  # `Nx.runtime_call`'s existing multi-output container/`:elem` machinery
+  # while still lowering to one `multi_op_registry` C++ instruction — no BEAM
+  # round-trip, same as every other op here, just without the extra metadata
+  # wrapper layer (which the multi-output case can't use).
+  #
+  # No `Nx.Defn.grad` support — this op only targets the (non-differentiable,
+  # forward-only) decode/generation loop.
+
+  @doc """
+  Fused decode-time KV-cache write (2× `put_slice`) + causal-masked SDPA read,
+  as one native op — the traced-graph analog of the hand-written
+  `EMLX.kv_cache_sdpa_update/7` eager NIF, but operating on the *full*
+  fixed-size preallocated cache with a *dynamic* (array-valued) `offset`
+  instead of a host int, so it can sit inside a compiled `:while` decode
+  loop without forcing a host readback per iteration.
+
+  All tensors use **Bumblebee-native, heads-NOT-transposed** layout (matching
+  `Bumblebee.Layers.Decoder.attention_cache/4`'s `{batch, seq, heads, head_dim}`
+  cache shape and `EMLXAxon`'s `build_sdpa_layer/5` pre-transpose inputs) — the
+  head-transpose SDPA itself needs is done internally, once, on `q` and on the
+  already-written `k_upd`/`v_upd`; the returned caches stay untransposed so
+  they can feed a `:while` carry directly with no extra transpose.
+
+  - `q`        — `{B, T_q,  N_q,  D}` (T_q = 1 for decode; not enforced)
+  - `new_k`    — `{B, T_q,  N_kv, D}`
+  - `new_v`    — `{B, T_q,  N_kv, D}`
+  - `k_cache`  — `{B, T_max, N_kv, D}`
+  - `v_cache`  — `{B, T_max, N_kv, D}`
+  - `offset`   — scalar/`{1}` int tensor — write position along the `T_max` axis
+  - `key_mask` — `{B, T_max}` — 1 = valid (readable), 0 = masked
+  - `scale`    — pre-computed scalar
+
+  Returns `{attn_out, k_cache_updated, v_cache_updated}` — `attn_out` is
+  **head-transposed**, `{B, N_q, T_q, D}` (matching what the unfused
+  `scaled_dot_product_attention_causal_key_masked/6` metadata node itself
+  already returns; callers transpose it back same as today), while the
+  updated caches keep `k_cache`/`v_cache`'s own (untransposed) shape.
+
+  Eager: composes plain `Nx.put_slice` ×2 (clamped host offset) +
+  `scaled_dot_product_attention_causal_key_masked/6` — deliberately
+  independent of the traced path's C++ formula below, so it doubles as an
+  correctness oracle for the native `multi_op_registry["kv_cache_sdpa_update"]`
+  kernel (same combined causal+key_mask formula, reimplemented once in
+  Elixir/Nx and once in C++).
+
+  Traced: lowers to one `multi_op_registry["kv_cache_sdpa_update"]`
+  (`emlx_compiler.cpp`) native IR instruction.
+  """
+  deftransform kv_cache_sdpa_update(q, new_k, new_v, k_cache, v_cache, offset, key_mask, scale) do
+    t_q = elem(Nx.shape(q), 1)
+    t_max = elem(Nx.shape(k_cache), 1)
+    kv_offset = if t_q == 1, do: t_max - 1, else: 0
+
+    offset = offset |> Nx.reshape({1}) |> Nx.as_type({:s, 32})
+    args = {q, new_k, new_v, k_cache, v_cache, offset, key_mask}
+
+    if traced?([q, new_k, new_v, k_cache, v_cache, offset, key_mask]) do
+      {qb, qt, qn, qd} = Nx.shape(q)
+      attn_template = Nx.template({qb, qn, qt, qd}, Nx.type(q))
+
+      out_template = {attn_template, Nx.to_template(k_cache), Nx.to_template(v_cache)}
+
+      Nx.runtime_call(
+        out_template,
+        args,
+        [
+          scale: scale,
+          kv_offset: kv_offset,
+          __emlx_native_multi_op__:
+            {:kv_cache_sdpa_update, [NativeExpr.f64_bits(scale), kv_offset]}
+        ],
+        &kv_cache_sdpa_update_callback/2
+      )
+    else
+      kv_cache_sdpa_update_callback(args, scale: scale, kv_offset: kv_offset)
+    end
+  end
+
+  @doc false
+  def kv_cache_sdpa_update_callback(
+        {%Nx.Tensor{} = q, %Nx.Tensor{} = new_k, %Nx.Tensor{} = new_v,
+         %Nx.Tensor{} = k_cache, %Nx.Tensor{} = v_cache, %Nx.Tensor{} = offset,
+         %Nx.Tensor{} = key_mask},
+        opts
+      ) do
+    scale = opts[:scale]
+    kv_offset = opts[:kv_offset]
+    t_max = elem(Nx.shape(k_cache), 1)
+
+    start =
+      offset |> Nx.reshape({}) |> Nx.as_type({:s, 64}) |> Nx.to_number() |> max(0) |> min(t_max - 1)
+
+    k_upd = Nx.put_slice(k_cache, [0, start, 0, 0], new_k)
+    v_upd = Nx.put_slice(v_cache, [0, start, 0, 0], new_v)
+
+    q_t = Nx.transpose(q, axes: [0, 2, 1, 3])
+    k_t = Nx.transpose(k_upd, axes: [0, 2, 1, 3])
+    v_t = Nx.transpose(v_upd, axes: [0, 2, 1, 3])
+
+    attn_out =
+      sdpa_causal_key_masked_callback({q_t, k_t, v_t, key_mask},
+        scale: scale,
+        kv_offset: kv_offset
+      )
+
+    {attn_out, k_upd, v_upd}
   end
 
   # ── RoPE ────────────────────────────────────────────────────────────────────

--- a/emlx/lib/emlx/native/expr.ex
+++ b/emlx/lib/emlx/native/expr.ex
@@ -80,7 +80,8 @@ defmodule EMLX.Native.Expr do
       while_nesting_depth: 0,
       stable_positions: %{},
       hook_chain_ref: nil,
-      hooked_value_refs: %{}
+      hooked_value_refs: %{},
+      refcounts: compute_refcounts(ordered)
     }
 
     state = Enum.reduce(ordered, state, &expand_node/2)
@@ -156,6 +157,246 @@ defmodule EMLX.Native.Expr do
       _, acc ->
         acc
     end)
+  end
+
+  # Same-scope reference count per node id — how many *other* nodes in
+  # `ordered` (or a `:while` subprogram's own `inner_ordered`) reference a
+  # given node as one of their `args`, via the same generic `Tree.apply_args`
+  # walk `EMLX.Defn.Tree.post_order/2` itself uses. Deliberately does **not**
+  # count a node being a top-level/subprogram *output leaf* (that's resolved
+  # via `node_to_ref` after the whole reduce, not via another node's args —
+  # see `lower/3`'s/`lower_while_subprogram/3`'s own `output_refs`/leaf
+  # lookups) — only used by the `:kv_cache_sdpa_update` peephole fusion
+  # (below) to verify it's safe to delete a node's already-emitted
+  # instruction (i.e. confirm the fused SDPA node is genuinely its *only*
+  # same-scope consumer) without needing to patch up some other, unrelated
+  # consumer that a naive fusion would otherwise leave dangling.
+  defp compute_refcounts(ordered) do
+    Enum.reduce(ordered, %{}, fn
+      # Mirrors `EMLX.Defn.Tree.visit_scope_deps/3`'s own two special cases
+      # exactly (`:fun` has no same-scope deps; `scope_dependencies/1`
+      # redirects `:metadata`/`__EMLX__` nodes to their `operands` list
+      # instead of their literal `args`) -- generic `Tree.apply_args/4` alone
+      # doesn't know about either, so it would (wrongly) report 0 references
+      # to a `:metadata` node's `__EMLX__` operands (e.g. an SDPA node's own
+      # Q/K/V), even though `post_order/2` *does* visit them as this node's
+      # dependencies. Must stay in lockstep with that module's traversal or
+      # the `kv_cache_sdpa_update` fusion's refcount==1 safety checks below
+      # silently never pass.
+      %T{data: %Nx.Defn.Expr{op: :fun}}, acc ->
+        acc
+
+      node, acc ->
+        deps =
+          case scope_dependencies(node) do
+            {:ok, deps} -> deps
+            :default -> apply_args_deps(node)
+          end
+
+        Enum.reduce(deps, acc, fn dep, a -> Map.update(a, dep.data.id, 1, &(&1 + 1)) end)
+    end)
+  end
+
+  defp apply_args_deps(node) do
+    {_, deps} =
+      Nx.Defn.Tree.apply_args(node, :scope, [], fn dep, acc -> {dep, [dep | acc]} end)
+
+    deps
+  end
+
+  # ── kv_cache_sdpa_update peephole fusion helpers ────────────────────────────
+  #
+  # Used by the `:fast_sdpa_causal_key_masked` `expand_node/2` clause below —
+  # kept out of the `expand_node/2` clause run itself so as not to break up
+  # that group (see this module's other private helpers, similarly kept
+  # outside the run).
+
+  @head_transpose_axes [0, 2, 1, 3]
+
+  defp match_kv_cache_sdpa_fusion(q_t, k_t, v_t, state) do
+    with {:ok, q} <- match_head_transpose(q_t),
+         {:ok, k_put_slice_chain, k_cache, k_offset, new_k} <- match_cache_put_slice(k_t),
+         {:ok, v_put_slice_chain, v_cache, v_offset, new_v} <- match_cache_put_slice(v_t),
+         true <- not match?(%T{data: %Nx.Defn.Expr{op: :constant}}, k_offset),
+         true <- k_offset.data.id == v_offset.data.id,
+         true <- Map.get(state.refcounts, q_t.data.id, 0) == 1,
+         true <- Map.get(state.refcounts, k_t.data.id, 0) == 1,
+         true <- Map.get(state.refcounts, v_t.data.id, 0) == 1,
+         true <- Map.get(state.refcounts, hd(k_put_slice_chain).data.id, 0) == 1,
+         true <- Map.get(state.refcounts, hd(v_put_slice_chain).data.id, 0) == 1 do
+      {:ok, q, new_k, new_v, k_cache, v_cache, k_offset, k_put_slice_chain, v_put_slice_chain}
+    else
+      _ -> :no_match
+    end
+  end
+
+  defp match_head_transpose(%T{data: %Nx.Defn.Expr{op: :transpose, args: [inner, axes]}}) do
+    if Enum.to_list(axes) == @head_transpose_axes, do: {:ok, inner}, else: :no_match
+  end
+
+  defp match_head_transpose(_), do: :no_match
+
+  # `k_t`/`v_t` (already known to be `transpose(_, [0,2,1,3])` by the time
+  # this is called) must wrap exactly `put_slice(cache, [0, offset, 0, 0],
+  # new_val)` — a dynamic (tensor-valued) `offset` at the T axis (axis 1,
+  # Bumblebee-native layout) and static 0 everywhere else. A static-integer
+  # `offset` (e.g. a one-shot prefill call, not inside a decode `:while`)
+  # intentionally does not match — fusion only pays off across many
+  # iterations, and requiring a dynamic offset here is a cheap, sufficient
+  # proxy for "this is a decode loop write" without inspecting scope depth.
+  defp match_cache_put_slice(%T{data: %Nx.Defn.Expr{op: :transpose, args: [put_slice_node, axes]}}) do
+    if Enum.to_list(axes) == @head_transpose_axes do
+      case unwrap_generic_metadata(put_slice_node) do
+        {:ok, aliases,
+         %T{data: %Nx.Defn.Expr{op: :put_slice, args: [cache, [ax0, offset, ax2, ax3], new_val]}} =
+             raw} ->
+          if static_zero?(ax0) and not static_zero?(offset) and static_zero?(ax2) and
+               static_zero?(ax3) do
+            {:ok, [raw | aliases], cache, offset, new_val}
+          else
+            :no_match
+          end
+
+        _ ->
+          :no_match
+      end
+    else
+      :no_match
+    end
+  end
+
+  defp match_cache_put_slice(_), do: :no_match
+
+  # Bumblebee/Axon wraps a named layer's output (e.g.
+  # `update_attention_cache`'s `put_slice`, whose result threads into both
+  # this SDPA read *and* the decode loop's carried cache state) in a
+  # generic `:metadata` node (`%{axon_layer: ...}`, no `__EMLX__`/
+  # `__EMLX_QUANT__` key) purely for introspection -- `expand_node/2`'s
+  # catch-all `:metadata` clause below aliases its id straight to the
+  # wrapped node's ref without emitting an instruction of its own. See
+  # through any number of these to find the real op, collecting every
+  # wrapper id along the way so `fuse_kv_cache_sdpa_instr/15` can redirect
+  # *all* of them (not just the raw `:put_slice`'s id) to the fused op's
+  # output ref -- otherwise a consumer reading through a wrapper id would
+  # keep resolving to the now-pruned `:put_slice` instruction's stale ref.
+  defp unwrap_generic_metadata(node, acc \\ [])
+
+  defp unwrap_generic_metadata(
+         %T{data: %Nx.Defn.Expr{op: :metadata, args: [inner, meta]}} = node,
+         acc
+       )
+       when not is_map_key(meta, :__EMLX__) and not is_map_key(meta, :__EMLX_QUANT__) do
+    unwrap_generic_metadata(inner, [node | acc])
+  end
+
+  defp unwrap_generic_metadata(node, acc), do: {:ok, acc, node}
+
+  # Traced `Nx.put_slice(cache, [0, offset, 0, 0], new)` calls normalize
+  # *every* `start_indices` entry to an `Nx.Defn.Expr` (constant tensors for
+  # the literal `0`s, not left as plain host integers) -- so a static "0" here
+  # is `%T{data: %Nx.Defn.Expr{op: :constant, args: [0]}}`, never a bare `0`.
+  defp static_zero?(0), do: true
+  defp static_zero?(%T{data: %Nx.Defn.Expr{op: :constant, args: [0]}}), do: true
+  defp static_zero?(_), do: false
+
+  # Test-observable fusion counter — bumped once per successful fusion
+  # (typically once per attention layer per model *compile*, not per token:
+  # a `:while` decode-loop body is lowered once and replayed natively). Cheap
+  # enough to leave unconditional (rare-write `:persistent_term`, and this
+  # only ever runs during `EMLX.Native.Expr.lower/3`, not on the hot decode
+  # path itself) — lets `EMLX.Native.ExprTest` assert the peephole actually
+  # fired, rather than silently falling through to the unfused path the
+  # whole time and only ever exercising `match_kv_cache_sdpa_fusion/4`'s
+  # `:no_match` branch.
+  @doc false
+  def kv_cache_fusion_count, do: :persistent_term.get(:emlx_kv_cache_fusion_count, 0)
+
+  @doc false
+  def reset_kv_cache_fusion_count, do: :persistent_term.put(:emlx_kv_cache_fusion_count, 0)
+
+  defp bump_kv_cache_fusion_count! do
+    :persistent_term.put(:emlx_kv_cache_fusion_count, kv_cache_fusion_count() + 1)
+  end
+
+  defp fuse_kv_cache_sdpa_instr(
+         id,
+         q,
+         new_k,
+         new_v,
+         k_cache,
+         v_cache,
+         offset,
+         key_mask,
+         attrs,
+         q_t,
+         k_t,
+         v_t,
+         k_put_slice_chain,
+         v_put_slice_chain,
+         state
+       ) do
+    bump_kv_cache_fusion_count!()
+
+    operands =
+      [q, new_k, new_v, k_cache, v_cache, offset, key_mask]
+      |> Enum.map(&Map.fetch!(state.node_to_ref, &1.data.id))
+
+    # Refs of the 5 now-dead instructions (Q's transpose; K/V's transpose +
+    # put_slice each) to strip from `state.instructions` -- otherwise the
+    # interpreter would still dispatch all 6 original ops *plus* this new
+    # fused one, a net dispatch-count *increase*, not the intended decrease.
+    # `hd/1` of each chain is enough here: every alias in a chain still
+    # resolves (pre-fusion) to the same single put_slice ref.
+    dead_refs =
+      MapSet.new(
+        Enum.map(
+          [q_t, k_t, v_t, hd(k_put_slice_chain), hd(v_put_slice_chain)],
+          &Map.fetch!(state.node_to_ref, &1.data.id)
+        )
+      )
+
+    pruned_instructions =
+      Enum.reject(state.instructions, fn {ref_or_refs, _op, _operands, _attrs} ->
+        case ref_or_refs do
+          refs when is_list(refs) -> Enum.any?(refs, &MapSet.member?(dead_refs, &1))
+          ref -> MapSet.member?(dead_refs, ref)
+        end
+      end)
+
+    attn_ref = make_ref()
+    k_upd_ref = make_ref()
+    v_upd_ref = make_ref()
+
+    # Every id in a put_slice chain (the raw `:put_slice` plus any generic
+    # `:metadata` wrapper ids around it) must be redirected to the new
+    # fused ref, not just the raw node's -- a wrapper id may be the one a
+    # *different* consumer (e.g. the decode loop's carried cache state)
+    # actually reads through.
+    node_to_ref =
+      state.node_to_ref
+      |> Map.put(id, attn_ref)
+      |> then(&Enum.reduce(k_put_slice_chain, &1, fn n, acc -> Map.put(acc, n.data.id, k_upd_ref) end))
+      |> then(&Enum.reduce(v_put_slice_chain, &1, fn n, acc -> Map.put(acc, n.data.id, v_upd_ref) end))
+
+    %{
+      state
+      | instructions: [
+          {[attn_ref, k_upd_ref, v_upd_ref], :kv_cache_sdpa_update, operands, attrs}
+          | pruned_instructions
+        ],
+        node_to_ref: node_to_ref
+    }
+  end
+
+  defp emit_metadata_instr(id, opcode, operands, attrs, state) do
+    ref = make_ref()
+    operand_refs = Enum.map(operands, &Map.fetch!(state.node_to_ref, &1.data.id))
+
+    %{
+      state
+      | instructions: [{ref, opcode, operand_refs, attrs} | state.instructions],
+        node_to_ref: Map.put(state.node_to_ref, id, ref)
+    }
   end
 
   # ── node expansion ────────────────────────────────────────────────────────
@@ -234,6 +475,64 @@ defmodule EMLX.Native.Expr do
     }
   end
 
+  # ── kv_cache_sdpa_update peephole fusion ────────────────────────────────────
+  # EMLXAxon's `build_sdpa_layer/5` always wraps its causal+key_mask SDPA
+  # call as `transpose(sdpa(transpose(q), transpose(k), transpose(v), ...))`
+  # (head-transpose in, head-transpose out — see that function), and its K/V
+  # arguments trace back to `Bumblebee.Layers.Decoder.update_attention_cache/5`
+  # (i.e. `Nx.put_slice(cache, [0, offset, 0, 0], new)`) whenever this SDPA
+  # node sits directly downstream of a KV-cache write, as in any decode loop.
+  # When that exact shape is confirmed (see `match_kv_cache_sdpa_fusion/4`,
+  # including refcount==1 safety checks — this is purely an optimization, so
+  # any mismatch silently falls through to the generic lowering below, never
+  # an error), rewrite `put_slice(K)` + `put_slice(V)` + `transpose` ×3 (Q,
+  # post-write K, post-write V) + this SDPA node — 6 native-IR instructions —
+  # into one `multi_op_registry["kv_cache_sdpa_update"]` (`emlx_compiler.cpp`)
+  # instruction.
+  defp expand_node(
+         %T{
+           data: %Nx.Defn.Expr{
+             id: id,
+             op: :metadata,
+             args: [
+               _inner,
+               %{
+                 __EMLX__: %{
+                   op: :fast_sdpa_causal_key_masked,
+                   operands: [q_t, k_t, v_t, key_mask],
+                   attrs: attrs
+                 }
+               }
+             ]
+           }
+         },
+         state
+       ) do
+    case match_kv_cache_sdpa_fusion(q_t, k_t, v_t, state) do
+      {:ok, q, new_k, new_v, k_cache, v_cache, offset, k_put_slice, v_put_slice} ->
+        fuse_kv_cache_sdpa_instr(
+          id,
+          q,
+          new_k,
+          new_v,
+          k_cache,
+          v_cache,
+          offset,
+          key_mask,
+          attrs,
+          q_t,
+          k_t,
+          v_t,
+          k_put_slice,
+          v_put_slice,
+          state
+        )
+
+      :no_match ->
+        emit_metadata_instr(id, :fast_sdpa_causal_key_masked, [q_t, k_t, v_t, key_mask], attrs, state)
+    end
+  end
+
   defp expand_node(
          %T{
            data: %Nx.Defn.Expr{
@@ -244,14 +543,7 @@ defmodule EMLX.Native.Expr do
          },
          state
        ) do
-    ref = make_ref()
-    operand_refs = Enum.map(operands, &Map.fetch!(state.node_to_ref, &1.data.id))
-
-    %{
-      state
-      | instructions: [{ref, opcode, operand_refs, attrs} | state.instructions],
-        node_to_ref: Map.put(state.node_to_ref, id, ref)
-    }
+    emit_metadata_instr(id, opcode, operands, attrs, state)
   end
 
   # `EMLX.Quantization.quantize/2`'s traced representation — see
@@ -1754,36 +2046,51 @@ defmodule EMLX.Native.Expr do
 
     operand_refs = Enum.map(operand_leaves, &Map.fetch!(state.node_to_ref, &1.data.id))
 
-    # A bare `%T{op: :parameter}` leaf is only a genuine top-level position
-    # when it IS a top-level parameter; inside a `:while` sub-program, `arg`'s
-    # parameters have their own local 0..N-1 numbering, unrelated to this
-    # program's real input list. `stable_positions` (populated by the
-    # top-level :parameter clause and propagated through invariant `while`
-    # carries by `expand_while_native/6`) resolves the correct position in
-    # both cases, and is `nil` when no such stable identity exists (e.g. the
-    # operand is computed, or a while carry that actually changes per
-    # iteration) -- see EMLX.handle_runtime_call/6's `positions` doc.
-    arg_param_positions =
-      Enum.map(operand_leaves, &Map.get(state.stable_positions, &1.data.id))
-
     output_templates =
       case out_template do
         %Nx.Tensor{} = t -> [t]
         container -> Composite.flatten_list([container])
       end
 
-    args_template = Composite.traverse(tensor_expr, &Nx.to_template/1)
-
     {result_refs, state} =
-      emit_runtime_call_refs(
-        operand_refs,
-        arg_param_positions,
-        args_template,
-        callback,
-        opts,
-        output_templates,
-        state
-      )
+      case Keyword.pop(opts, :__emlx_native_multi_op__) do
+        {nil, _opts} ->
+          # A bare `%T{op: :parameter}` leaf is only a genuine top-level
+          # position when it IS a top-level parameter; inside a `:while`
+          # sub-program, `arg`'s parameters have their own local 0..N-1
+          # numbering, unrelated to this program's real input list.
+          # `stable_positions` (populated by the top-level :parameter clause
+          # and propagated through invariant `while` carries by
+          # `expand_while_native/6`) resolves the correct position in both
+          # cases, and is `nil` when no such stable identity exists (e.g. the
+          # operand is computed, or a while carry that actually changes per
+          # iteration) -- see EMLX.handle_runtime_call/6's `positions` doc.
+          arg_param_positions =
+            Enum.map(operand_leaves, &Map.get(state.stable_positions, &1.data.id))
+
+          args_template = Composite.traverse(tensor_expr, &Nx.to_template/1)
+
+          emit_runtime_call_refs(
+            operand_refs,
+            arg_param_positions,
+            args_template,
+            callback,
+            opts,
+            output_templates,
+            state
+          )
+
+        {{native_opcode, native_attrs}, _opts} ->
+          # Escape hatch for a genuine `multi_op_registry` C++ op (no BEAM
+          # round-trip, unlike the `EMLXRuntimeCall`/`invoke_runtime_call`
+          # path above) that still wants `Nx.runtime_call`'s existing
+          # multi-output container/`:elem` machinery and eager/grad-fallback
+          # callback for free, instead of duplicating that plumbing. `callback`
+          # is kept as this node's eager/`Nx.Defn.Evaluator`/`Nx.Defn.Grad`
+          # fallback (never invoked on this native-compiled path); only the
+          # opcode + static attrs reach the interpreter.
+          emit_native_multi_op_refs(operand_refs, native_opcode, native_attrs, output_templates, state)
+      end
 
     result_id =
       case out_template do
@@ -1859,6 +2166,26 @@ defmodule EMLX.Native.Expr do
       state
       | instructions: [{result_refs, :runtime_call, operand_refs, attrs} | state.instructions],
         runtime_calls: [runtime_call | state.runtime_calls]
+    }
+
+    {result_refs, state}
+  end
+
+  # Sibling of `emit_runtime_call_refs/7` for the `:__emlx_native_multi_op__`
+  # escape hatch (see the `:runtime_call` `expand_node/2` clause above):
+  # emits one plain multi-output instruction dispatched to `opcode`
+  # (expected to resolve via `emlx_compiler.cpp`'s `multi_op_registry`, the
+  # same mechanism already backing `qr`/`svd`/`lu` -- pure native C++, no
+  # `EMLXRuntimeCall`/BEAM round-trip, unlike `emit_runtime_call_refs/7`).
+  # `attrs` are static (baked in at trace time, like every other op's attrs);
+  # any per-iteration-dynamic values must instead be threaded as extra
+  # `operand_refs` (see `:put_slice`'s dynamic-start-index pattern).
+  defp emit_native_multi_op_refs(operand_refs, opcode, attrs, output_templates, state) do
+    result_refs = Enum.map(output_templates, fn _ -> make_ref() end)
+
+    state = %{
+      state
+      | instructions: [{result_refs, opcode, operand_refs, attrs} | state.instructions]
     }
 
     {result_refs, state}
@@ -2525,7 +2852,12 @@ defmodule EMLX.Native.Expr do
     inner_state =
       Enum.reduce(
         inner_ordered,
-        %{state | node_to_ref: local_base, instructions: []},
+        %{
+          state
+          | node_to_ref: local_base,
+            instructions: [],
+            refcounts: compute_refcounts(inner_ordered)
+        },
         fn node, st ->
           if MapSet.member?(param_id_set, node.data.id), do: st, else: expand_node(node, st)
         end

--- a/emlx/lib/emlx/native/expr.ex
+++ b/emlx/lib/emlx/native/expr.ex
@@ -244,7 +244,9 @@ defmodule EMLX.Native.Expr do
   # intentionally does not match — fusion only pays off across many
   # iterations, and requiring a dynamic offset here is a cheap, sufficient
   # proxy for "this is a decode loop write" without inspecting scope depth.
-  defp match_cache_put_slice(%T{data: %Nx.Defn.Expr{op: :transpose, args: [put_slice_node, axes]}}) do
+  defp match_cache_put_slice(%T{
+         data: %Nx.Defn.Expr{op: :transpose, args: [put_slice_node, axes]}
+       }) do
     if Enum.to_list(axes) == @head_transpose_axes do
       case unwrap_generic_metadata(put_slice_node) do
         {:ok, aliases,
@@ -375,8 +377,12 @@ defmodule EMLX.Native.Expr do
     node_to_ref =
       state.node_to_ref
       |> Map.put(id, attn_ref)
-      |> then(&Enum.reduce(k_put_slice_chain, &1, fn n, acc -> Map.put(acc, n.data.id, k_upd_ref) end))
-      |> then(&Enum.reduce(v_put_slice_chain, &1, fn n, acc -> Map.put(acc, n.data.id, v_upd_ref) end))
+      |> then(
+        &Enum.reduce(k_put_slice_chain, &1, fn n, acc -> Map.put(acc, n.data.id, k_upd_ref) end)
+      )
+      |> then(
+        &Enum.reduce(v_put_slice_chain, &1, fn n, acc -> Map.put(acc, n.data.id, v_upd_ref) end)
+      )
 
     %{
       state
@@ -529,7 +535,13 @@ defmodule EMLX.Native.Expr do
         )
 
       :no_match ->
-        emit_metadata_instr(id, :fast_sdpa_causal_key_masked, [q_t, k_t, v_t, key_mask], attrs, state)
+        emit_metadata_instr(
+          id,
+          :fast_sdpa_causal_key_masked,
+          [q_t, k_t, v_t, key_mask],
+          attrs,
+          state
+        )
     end
   end
 
@@ -2089,7 +2101,13 @@ defmodule EMLX.Native.Expr do
           # is kept as this node's eager/`Nx.Defn.Evaluator`/`Nx.Defn.Grad`
           # fallback (never invoked on this native-compiled path); only the
           # opcode + static attrs reach the interpreter.
-          emit_native_multi_op_refs(operand_refs, native_opcode, native_attrs, output_templates, state)
+          emit_native_multi_op_refs(
+            operand_refs,
+            native_opcode,
+            native_attrs,
+            output_templates,
+            state
+          )
       end
 
     result_id =

--- a/emlx/test/emlx/fast_test.exs
+++ b/emlx/test/emlx/fast_test.exs
@@ -311,6 +311,44 @@ defmodule EMLX.FastTest do
       assert Nx.shape(out) == {1, 16, 1, 64}
       assert Nx.type(out) == {:f, 16}
     end
+
+    @tag :metal
+    test "left-padded prefill: padding query rows do not produce NaN (regression)" do
+      # Reproduces the "!!!!" degenerate-output bug found in bb+rewrite
+      # generation: for a left-padded prefill (T_q = T_kv, key_mask marks
+      # only a right-aligned suffix as valid), the padding query rows (whose
+      # own position is < the first valid key) have an EMPTY causal ∩
+      # key_mask intersection -- their additive mask row is all -inf, so
+      # softmax(-inf, ..., -inf) = NaN. Uncaught, this NaN then contaminates
+      # every subsequent decode step through the KV cache, producing garbage
+      # output for the entire generation (observed non-deterministically,
+      # correlated with T_kv hitting certain Metal SDPA tile-size boundaries).
+      # Shapes mirror Qwen3-0.6B: 16 query heads, 8 KV heads (GQA groups=2),
+      # head_dim=128 -- matches the real reproduction (constant/uniform
+      # values and/or non-GQA head counts did not reproduce the bug).
+      t_kv = 80
+      valid_len = 19
+      key = Nx.Random.key(42)
+
+      {q, key} = Nx.Random.normal(key, shape: {1, 16, t_kv, 128}, type: :bf16)
+      {k, key} = Nx.Random.normal(key, shape: {1, 8, t_kv, 128}, type: :bf16)
+      {v, _key} = Nx.Random.normal(key, shape: {1, 8, t_kv, 128}, type: :bf16)
+      q = gpu(q)
+      k = gpu(k)
+      v = gpu(v)
+      scale = 1.0 / :math.sqrt(128)
+
+      mask_row =
+        for i <- 0..(t_kv - 1) do
+          if i >= t_kv - valid_len, do: 1, else: 0
+        end
+
+      key_mask = Nx.tensor([mask_row]) |> gpu()
+
+      out = Fast.scaled_dot_product_attention_causal_key_masked(q, k, v, scale, key_mask)
+
+      refute out |> Nx.is_nan() |> Nx.any() |> Nx.to_number() == 1
+    end
   end
 
   describe "EMLX.kv_cache_sdpa_update/7" do

--- a/emlx/test/emlx/fast_test.exs
+++ b/emlx/test/emlx/fast_test.exs
@@ -354,6 +354,57 @@ defmodule EMLX.FastTest do
     end
   end
 
+  describe "EMLX.Fast.kv_cache_sdpa_update/8 (eager)" do
+    test "writes new_k/new_v at offset and matches put_slice+causal_key_masked reference" do
+      # Bumblebee-native layout: {B, T, N, D} (heads NOT transposed).
+      q = Nx.iota({1, 1, 2, 4}, type: :f32) |> Nx.divide(100) |> gpu()
+      new_k = Nx.iota({1, 1, 1, 4}, type: :f32) |> Nx.divide(200) |> gpu()
+      new_v = Nx.iota({1, 1, 1, 4}, type: :f32) |> Nx.divide(300) |> gpu()
+      k_cache = Nx.iota({1, 5, 1, 4}, type: :f32) |> Nx.divide(50) |> gpu()
+      v_cache = Nx.iota({1, 5, 1, 4}, type: :f32) |> Nx.divide(60) |> gpu()
+      offset = Nx.tensor(2, type: :s32) |> gpu()
+      key_mask = Nx.tensor([[1, 1, 1, 0, 0]], type: :s32) |> gpu()
+      scale = 1.0 / :math.sqrt(4)
+
+      {attn, k_upd, v_upd} =
+        Fast.kv_cache_sdpa_update(q, new_k, new_v, k_cache, v_cache, offset, key_mask, scale)
+
+      # attn_out is head-transposed ({B, N, T, D}), matching the unfused
+      # metadata node's own output convention; k_upd/v_upd stay
+      # Bumblebee-native ({B, T, N, D}), matching the cache's own shape.
+      assert Nx.shape(attn) == {1, 2, 1, 4}
+      assert Nx.shape(k_upd) == {1, 5, 1, 4}
+      assert Nx.shape(v_upd) == {1, 5, 1, 4}
+
+      # Compute the unfused reference (reusing new_k/new_v/k_cache/v_cache)
+      # *before* any `Nx.backend_transfer/1` call below, since that deallocates
+      # its (single) argument's underlying EMLX resource -- see
+      # `EMLX.Backend.backend_transfer/3`.
+      k_ref = Nx.put_slice(k_cache, [0, 2, 0, 0], new_k)
+      v_ref = Nx.put_slice(v_cache, [0, 2, 0, 0], new_v)
+      q_t = Nx.transpose(q, axes: [0, 2, 1, 3])
+      k_ref_t = Nx.transpose(k_ref, axes: [0, 2, 1, 3])
+      v_ref_t = Nx.transpose(v_ref, axes: [0, 2, 1, 3])
+
+      attn_ref =
+        Fast.scaled_dot_product_attention_causal_key_masked(q_t, k_ref_t, v_ref_t, scale, key_mask)
+
+      assert_all_close(
+        Nx.slice_along_axis(k_upd, 2, 1, axis: 1) |> Nx.backend_transfer(),
+        Nx.backend_transfer(new_k),
+        atol: 1.0e-5
+      )
+
+      assert_all_close(
+        Nx.slice_along_axis(v_upd, 2, 1, axis: 1) |> Nx.backend_transfer(),
+        Nx.backend_transfer(new_v),
+        atol: 1.0e-5
+      )
+
+      assert_all_close(Nx.backend_transfer(attn), Nx.backend_transfer(attn_ref), atol: 1.0e-3)
+    end
+  end
+
   describe "EMLX.causal_kv_attention/7" do
     test "prefill updates compact GQA cache and returns attention output" do
       {q_cpu, new_k_cpu, new_v_cpu, k_cache_cpu, v_cache_cpu, key_mask_cpu} =

--- a/emlx/test/emlx/fast_test.exs
+++ b/emlx/test/emlx/fast_test.exs
@@ -387,7 +387,13 @@ defmodule EMLX.FastTest do
       v_ref_t = Nx.transpose(v_ref, axes: [0, 2, 1, 3])
 
       attn_ref =
-        Fast.scaled_dot_product_attention_causal_key_masked(q_t, k_ref_t, v_ref_t, scale, key_mask)
+        Fast.scaled_dot_product_attention_causal_key_masked(
+          q_t,
+          k_ref_t,
+          v_ref_t,
+          scale,
+          key_mask
+        )
 
       assert_all_close(
         Nx.slice_along_axis(k_upd, 2, 1, axis: 1) |> Nx.backend_transfer(),

--- a/emlx/test/emlx/native/expr_test.exs
+++ b/emlx/test/emlx/native/expr_test.exs
@@ -3252,7 +3252,10 @@ defmodule EMLX.Native.ExprTest do
         q_t = Nx.transpose(q, axes: [0, 2, 1, 3])
         k_t = Nx.transpose(k_upd, axes: [0, 2, 1, 3])
         v_t = Nx.transpose(v_upd, axes: [0, 2, 1, 3])
-        attn = EMLX.Fast.scaled_dot_product_attention_causal_key_masked(q_t, k_t, v_t, 0.125, key_mask)
+
+        attn =
+          EMLX.Fast.scaled_dot_product_attention_causal_key_masked(q_t, k_t, v_t, 0.125, key_mask)
+
         {attn, k_upd, v_upd}
       end
 
@@ -3328,7 +3331,10 @@ defmodule EMLX.Native.ExprTest do
       EMLX.Native.Expr.reset_kv_cache_fusion_count()
 
       {fused_k, fused_v, fused_attn} =
-        Nx.Defn.jit(&EMLX.Native.ExprTest.kv_cache_while_auto_fuse/5, compiler: EMLX, device: :gpu).(
+        Nx.Defn.jit(&EMLX.Native.ExprTest.kv_cache_while_auto_fuse/5,
+          compiler: EMLX,
+          device: :gpu
+        ).(
           q,
           k0,
           v0,

--- a/emlx/test/emlx/native/expr_test.exs
+++ b/emlx/test/emlx/native/expr_test.exs
@@ -112,6 +112,91 @@ defmodule EMLX.Native.ExprTest do
     result
   end
 
+  # P01 restart (Procedure step 3) spike: `EMLX.Fast.kv_cache_sdpa_update/8`
+  # (native multi-op escape hatch) threaded through a compiled `:while`
+  # `:carry` across 3 iterations, one fused call per iteration -- the shape
+  # of its actual intended use (a decode loop, one call per layer per step).
+  # `while` (`Nx.Defn.Kernel`) only works inside a real `defn` body, hence
+  # this being a module-level defn rather than an anonymous fn built inside
+  # the test itself (see the sibling `..._ref/5` below for the unfused
+  # comparison point, called from the same describe block).
+  defn kv_cache_while_fused(q, k0, v0, k_cache0, v_cache0) do
+    {_q, _k0, _v0, k_final, v_final, attn_sum, _i} =
+      while {q, k0, v0, k_cache = k_cache0, v_cache = v_cache0,
+             acc = Nx.broadcast(0.0, {1, 2, 1, 8}), i = 0},
+            Nx.less(i, 3) do
+        offset = i
+        key_mask = Nx.less_equal(Nx.iota({1, 5}, type: :s32), offset)
+
+        {attn, k_cache, v_cache} =
+          EMLX.Fast.kv_cache_sdpa_update(q, k0, v0, k_cache, v_cache, offset, key_mask, 0.125)
+
+        {q, k0, v0, k_cache, v_cache, Nx.add(acc, attn), i + 1}
+      end
+
+    {k_final, v_final, attn_sum}
+  end
+
+  # Unfused reference for `kv_cache_while_fused/5` above: plain
+  # `Nx.put_slice` ×2 + `EMLX.Fast.scaled_dot_product_attention_causal_key_masked/5`
+  # composed by hand inside the identical `:while` skeleton.
+  defn kv_cache_while_ref(q, k0, v0, k_cache0, v_cache0) do
+    {_q, _k0, _v0, k_final, v_final, attn_sum, _i} =
+      while {q, k0, v0, k_cache = k_cache0, v_cache = v_cache0,
+             acc = Nx.broadcast(0.0, {1, 2, 1, 8}), i = 0},
+            Nx.less(i, 3) do
+        offset = i
+        key_mask = Nx.less_equal(Nx.iota({1, 5}, type: :s32), offset)
+        k_cache = Nx.put_slice(k_cache, [0, offset, 0, 0], k0)
+        v_cache = Nx.put_slice(v_cache, [0, offset, 0, 0], v0)
+
+        attn =
+          EMLX.Fast.scaled_dot_product_attention_causal_key_masked(
+            Nx.transpose(q, axes: [0, 2, 1, 3]),
+            Nx.transpose(k_cache, axes: [0, 2, 1, 3]),
+            Nx.transpose(v_cache, axes: [0, 2, 1, 3]),
+            0.125,
+            key_mask
+          )
+
+        {q, k0, v0, k_cache, v_cache, Nx.add(acc, attn), i + 1}
+      end
+
+    {k_final, v_final, attn_sum}
+  end
+
+  # Auto-fusion probe for the `kv_cache_sdpa_update` *peephole* pass (see
+  # `EMLX.Native.Expr`'s `:fast_sdpa_causal_key_masked` `expand_node/2`
+  # clause) — unlike `kv_cache_while_fused/5` above (which calls
+  # `EMLX.Fast.kv_cache_sdpa_update/8` directly), this hand-composes plain
+  # `Nx.put_slice` ×2 + `Nx.transpose` ×3 + `scaled_dot_product_attention_causal_key_masked/5`
+  # exactly as `EMLXAxon.build_sdpa_layer/5` does, so it exercises the
+  # pattern-detector itself, not just the escape-hatch it targets. Should
+  # produce numerically identical results to `kv_cache_while_ref/5` (byte for
+  # byte the same computation) while triggering the fusion internally.
+  defn kv_cache_while_auto_fuse(q, k0, v0, k_cache0, v_cache0) do
+    {_q, _k0, _v0, k_final, v_final, attn_sum, _i} =
+      while {q, k0, v0, k_cache = k_cache0, v_cache = v_cache0,
+             acc = Nx.broadcast(0.0, {1, 2, 1, 8}), i = 0},
+            Nx.less(i, 3) do
+        offset = i
+        key_mask = Nx.less_equal(Nx.iota({1, 5}, type: :s32), offset)
+        k_cache = Nx.put_slice(k_cache, [0, offset, 0, 0], k0)
+        v_cache = Nx.put_slice(v_cache, [0, offset, 0, 0], v0)
+
+        q_t = Nx.transpose(q, axes: [0, 2, 1, 3])
+        k_t = Nx.transpose(k_cache, axes: [0, 2, 1, 3])
+        v_t = Nx.transpose(v_cache, axes: [0, 2, 1, 3])
+
+        attn =
+          EMLX.Fast.scaled_dot_product_attention_causal_key_masked(q_t, k_t, v_t, 0.125, key_mask)
+
+        {q, k0, v0, k_cache, v_cache, Nx.add(acc, attn), i + 1}
+      end
+
+    {k_final, v_final, attn_sum}
+  end
+
   defn quantized_matmul_surrounded(x, qw) do
     EMLX.Quantization.quantized_matmul(x, qw) |> Nx.add(1.0) |> Nx.multiply(2.0)
   end
@@ -3103,6 +3188,169 @@ defmodule EMLX.Native.ExprTest do
       native_ap = Nx.Defn.jit(fun, compiler: EMLX, device: :gpu).(q, k, v, all_present, sinks)
       eager_ap = Nx.Defn.jit(fun, compiler: Nx.Defn.Evaluator).(q, k, v, all_present, sinks)
       assert_all_close(native_ap, eager_ap, tol: 1.0e-3)
+    end
+
+    # P01 restart (Procedure step 3) spike: multi-output escape hatch
+    # (`Nx.runtime_call`'s `:__emlx_native_multi_op__` opt, see
+    # `EMLX.Native.Expr`'s `:runtime_call` expand_node clause) lowering
+    # straight to `multi_op_registry["kv_cache_sdpa_update"]`
+    # (emlx_compiler.cpp) — unlike every other test in this describe block,
+    # this op does NOT go through the single-output `:__EMLX__` metadata
+    # mechanism (see `EMLX.Fast.kv_cache_sdpa_update/8`'s moduledoc comment).
+    test "kv_cache_sdpa_update: fused native replay matches eager and matches put_slice+sdpa reference" do
+      fun = fn q, new_k, new_v, k_cache, v_cache, offset, key_mask ->
+        EMLX.Fast.kv_cache_sdpa_update(
+          q,
+          new_k,
+          new_v,
+          k_cache,
+          v_cache,
+          offset,
+          key_mask,
+          0.125
+        )
+      end
+
+      # Bumblebee-native layout: {B, T, N, D} (heads NOT transposed).
+      q = Nx.iota({1, 1, 2, 8}, type: :f32) |> Nx.divide(100) |> gpu_t()
+      new_k = Nx.iota({1, 1, 1, 8}, type: :f32) |> Nx.divide(90) |> gpu_t()
+      new_v = Nx.iota({1, 1, 1, 8}, type: :f32) |> Nx.divide(80) |> gpu_t()
+      k_cache = Nx.iota({1, 5, 1, 8}, type: :f32) |> Nx.divide(70) |> gpu_t()
+      v_cache = Nx.iota({1, 5, 1, 8}, type: :f32) |> Nx.divide(60) |> gpu_t()
+      offset = Nx.tensor(2, type: :s32) |> gpu_t()
+      key_mask = Nx.tensor([[1, 1, 1, 0, 0]], type: :s32) |> gpu_t()
+
+      {native_attn, native_k, native_v} =
+        Nx.Defn.jit(fun, compiler: EMLX, device: :gpu).(
+          q,
+          new_k,
+          new_v,
+          k_cache,
+          v_cache,
+          offset,
+          key_mask
+        )
+
+      {eager_attn, eager_k, eager_v} =
+        Nx.Defn.jit(fun, compiler: Nx.Defn.Evaluator).(
+          q,
+          new_k,
+          new_v,
+          k_cache,
+          v_cache,
+          offset,
+          key_mask
+        )
+
+      assert_all_close(native_attn, eager_attn, tol: 1.0e-3)
+      assert_all_close(native_k, eager_k, tol: 1.0e-5)
+      assert_all_close(native_v, eager_v, tol: 1.0e-5)
+
+      prim_fun = fn q, new_k, new_v, k_cache, v_cache, key_mask ->
+        k_upd = Nx.put_slice(k_cache, [0, 2, 0, 0], new_k)
+        v_upd = Nx.put_slice(v_cache, [0, 2, 0, 0], new_v)
+        q_t = Nx.transpose(q, axes: [0, 2, 1, 3])
+        k_t = Nx.transpose(k_upd, axes: [0, 2, 1, 3])
+        v_t = Nx.transpose(v_upd, axes: [0, 2, 1, 3])
+        attn = EMLX.Fast.scaled_dot_product_attention_causal_key_masked(q_t, k_t, v_t, 0.125, key_mask)
+        {attn, k_upd, v_upd}
+      end
+
+      {prim_attn, prim_k, prim_v} =
+        Nx.Defn.jit(prim_fun, compiler: EMLX, device: :gpu).(
+          q,
+          new_k,
+          new_v,
+          k_cache,
+          v_cache,
+          key_mask
+        )
+
+      assert_all_close(native_attn, prim_attn, tol: 1.0e-3)
+      assert_all_close(native_k, prim_k, tol: 1.0e-5)
+      assert_all_close(native_v, prim_v, tol: 1.0e-5)
+    end
+
+    # Same op threaded through a compiled `:while`'s `:carry` (the shape of
+    # its actual intended use — a Qwen3-style decode loop, one fused call
+    # per layer per step) instead of a single top-level call, to verify the
+    # native multi-op escape hatch survives `:while`'s carry/keepalive
+    # machinery (result-ref list, per-iteration replay) across several
+    # iterations, not just one bare top-level call.
+    test "kv_cache_sdpa_update inside a compiled :while decode loop matches an unfused reference loop" do
+      q = Nx.iota({1, 1, 2, 8}, type: :f32) |> Nx.divide(100) |> gpu_t()
+      k0 = Nx.iota({1, 1, 1, 8}, type: :f32) |> Nx.divide(90) |> gpu_t()
+      v0 = Nx.iota({1, 1, 1, 8}, type: :f32) |> Nx.divide(80) |> gpu_t()
+      k_cache0 = Nx.broadcast(0.0, {1, 5, 1, 8}) |> Nx.as_type(:f32) |> gpu_t()
+      v_cache0 = Nx.broadcast(0.0, {1, 5, 1, 8}) |> Nx.as_type(:f32) |> gpu_t()
+
+      {fused_k, fused_v, fused_attn} =
+        Nx.Defn.jit(&EMLX.Native.ExprTest.kv_cache_while_fused/5, compiler: EMLX, device: :gpu).(
+          q,
+          k0,
+          v0,
+          k_cache0,
+          v_cache0
+        )
+
+      {ref_k, ref_v, ref_attn} =
+        Nx.Defn.jit(&EMLX.Native.ExprTest.kv_cache_while_ref/5, compiler: EMLX, device: :gpu).(
+          q,
+          k0,
+          v0,
+          k_cache0,
+          v_cache0
+        )
+
+      assert_all_close(fused_k, ref_k, tol: 1.0e-3)
+      assert_all_close(fused_v, ref_v, tol: 1.0e-3)
+      assert_all_close(fused_attn, ref_attn, tol: 1.0e-3)
+    end
+
+    # Exercises the *peephole detector* itself (`match_kv_cache_sdpa_fusion/4`
+    # and friends), as opposed to the tests above which call
+    # `EMLX.Fast.kv_cache_sdpa_update/8` directly and never touch the
+    # pattern-matcher at all. `kv_cache_while_auto_fuse/5` hand-composes
+    # `Nx.put_slice` ×2 + `Nx.transpose` ×3 + causal SDPA exactly like
+    # `EMLXAxon.build_sdpa_layer/5` does — if the detector's pattern (or the
+    # refcount==1 safety checks) ever drifts from what that function
+    # actually produces, this is the test that should catch it via the
+    # fusion-count assertion below (a pure numeric comparison against
+    # `kv_cache_while_ref/5` would still pass even if the fusion silently
+    # never fired).
+    test "kv_cache_sdpa_update peephole fusion fires on EMLXAxon's build_sdpa_layer-shaped pattern" do
+      q = Nx.iota({1, 1, 2, 8}, type: :f32) |> Nx.divide(100) |> gpu_t()
+      k0 = Nx.iota({1, 1, 1, 8}, type: :f32) |> Nx.divide(90) |> gpu_t()
+      v0 = Nx.iota({1, 1, 1, 8}, type: :f32) |> Nx.divide(80) |> gpu_t()
+      k_cache0 = Nx.broadcast(0.0, {1, 5, 1, 8}) |> Nx.as_type(:f32) |> gpu_t()
+      v_cache0 = Nx.broadcast(0.0, {1, 5, 1, 8}) |> Nx.as_type(:f32) |> gpu_t()
+
+      EMLX.Native.Expr.reset_kv_cache_fusion_count()
+
+      {fused_k, fused_v, fused_attn} =
+        Nx.Defn.jit(&EMLX.Native.ExprTest.kv_cache_while_auto_fuse/5, compiler: EMLX, device: :gpu).(
+          q,
+          k0,
+          v0,
+          k_cache0,
+          v_cache0
+        )
+
+      assert EMLX.Native.Expr.kv_cache_fusion_count() > 0,
+             "expected the kv_cache_sdpa_update peephole to fire at least once"
+
+      {ref_k, ref_v, ref_attn} =
+        Nx.Defn.jit(&EMLX.Native.ExprTest.kv_cache_while_ref/5, compiler: EMLX, device: :gpu).(
+          q,
+          k0,
+          v0,
+          k_cache0,
+          v_cache0
+        )
+
+      assert_all_close(fused_k, ref_k, tol: 1.0e-3)
+      assert_all_close(fused_v, ref_v, tol: 1.0e-3)
+      assert_all_close(fused_attn, ref_attn, tol: 1.0e-3)
     end
 
     test "rope (scalar offset): fused replay matches eager" do

--- a/emlx_axon/bench/metal_capture_native.exs
+++ b/emlx_axon/bench/metal_capture_native.exs
@@ -6,7 +6,15 @@
 #
 # Run:
 #   cd emlx_axon
-#   mix run bench/metal_capture_native.exs
+#   MTL_CAPTURE_ENABLED=1 mix run bench/metal_capture_native.exs
+#
+# Required env var:
+#   MTL_CAPTURE_ENABLED=1  — Apple's process-level Metal capture gate. MUST be
+#                            set before the BEAM (and therefore the Metal
+#                            device) starts — it is read once at process
+#                            startup and cannot be enabled lazily from inside
+#                            this script. Without it, EMLX.metal_start_capture/1
+#                            raises (does not silently no-op, on MLX 0.31.2).
 #
 # Optional env vars:
 #   EMLX_QWEN3_MODEL_PATH  — path to Qwen3-0.6B-MLX-4bit checkout

--- a/emlx_axon/lib/emlx_axon/text_generation.ex
+++ b/emlx_axon/lib/emlx_axon/text_generation.ex
@@ -324,7 +324,7 @@ defmodule EMLXAxon.TextGeneration do
         # `Nx.Batch` stays lazy until a defn/jit entry; `jit_apply(identity)` is the
         # supported way to concatenate stacked entries into concrete tensors.
         %{"input_ids" => input_ids} =
-          Nx.Defn.jit_apply(&Function.identity/1, [batch], opts[:defn_options])
+          Nx.Defn.jit_apply(&Function.identity/1, [batch], Keyword.get(opts, :defn_options, []))
 
         ensure_single_batch!(input_ids)
 


### PR DESCRIPTION
Increases best-case scenario Native Qwen3 0.6B 4bit implementation to 300 tok/s under nice conditions and EMLX Axon rewrites to 100 tok/s

Benchmarks below (M4 Max 64GB)
For each entry, > 1 means `row` is faster than `col`

### Qwen3-0.6B (dense bf16)

| row ∖ col (row / col) | bb base | bb+rewrite | native | emily-eager | emily-native |
| --- | --- | --- | --- | --- | --- |
| **bb base** | – | 0.51× | 0.77× | 5.71× | 0.82× |
| **bb+rewrite** | 1.95× | – | 1.51× | 11.17× | 1.6× |
| **native** | 1.3× | 0.66× | – | 7.42× | 1.06× |
| **emily-eager** | 0.17× | 0.09× | 0.13× | – | 0.14× |
| **emily-native** | 1.23× | 0.63× | 0.94× | 7.0× | – |

- **bb base**: median=64.0  mean=63.2±1.7  min/max=60.5/65.1 tok/s
- **bb+rewrite**: median=125.1  mean=124.5±2.5  min/max=120.0/127.6 tok/s
- **native**: median=83.1  mean=83.0±0.2  min/max=82.6/83.2 tok/s
- **emily-eager**: median=11.2  mean=11.2±0.1  min/max=11.0/11.4 tok/s
- **emily-native**: median=78.4  mean=78.0±2.0  min/max=75.0/80.7 tok/s

---

### Qwen3-0.6B-MLX-4bit

| row ∖ col (row / col) | bb base | bb+rewrite | native | emily-quantized |
| --- | --- | --- | --- | --- |
| **bb base** | – | 0.53× | 0.19× | 1× | 3.05× |
| **native** | 5.27× | 2.8× | – | 8.55× |
| **emily-quantized** | 0.62× | 0.33× | 0.12× | – |

- **bb base**: median=62.1  mean=62.0±0.9  min/max=60.7/63.3 tok/s
- **bb+rewrite**: median=116.9  mean=117.5±2.6  min/max=114.4/122.4 tok/s
- **native**: median=327.3  mean=320.5±14.0  min/max=294.1/332.8 tok/s
- **emily-quantized**: median=38.3  mean=38.3±0.1  min/max=38.2/38.4 tok/s
