### PR TITLE
Add native dense Llama generation to EMLXAxon

### DIFF
--- a/.github/workflows/emlx_axon.yml
+++ b/.github/workflows/emlx_axon.yml
@@ -73,12 +73,17 @@ jobs:
 
       - name: Install emlx_axon dependencies
         working-directory: emlx_axon
+        env:
+          EMLX_AXON_LOCAL_EMLX: "true"
         run: |
           export PATH="${{ steps.setup.outputs.path }}:${PATH}"
+          rm -rf deps/emlx _build/dev/lib/emlx _build/test/lib/emlx
           mix deps.get
 
       - name: Check formatting
         working-directory: emlx_axon
+        env:
+          EMLX_AXON_LOCAL_EMLX: "true"
         run: |
           export PATH="${{ steps.setup.outputs.path }}:${PATH}"
           mix format --check-formatted
@@ -86,6 +91,7 @@ jobs:
       - name: Run emlx_axon tests
         working-directory: emlx_axon
         env:
+          EMLX_AXON_LOCAL_EMLX: "true"
           EMLX_TEST_DEFAULT_GPU: "true"
         run: |
           export PATH="${{ steps.setup.outputs.path }}:${PATH}"

--- a/emlx/Makefile
+++ b/emlx/Makefile
@@ -7,7 +7,7 @@ esc = $(subst $(space),\$(space),$(1))
 
 # Private configuration
 PRIV_DIR = $(MIX_APP_PATH)/priv
-BUILD_DIR = $(EMLX_CACHE_DIR)/emlx-$(EMLX_VERSION)-mlx-$(MLX_VERSION)$(MLX_VARIANT)/objs
+BUILD_DIR = $(EMLX_CACHE_DIR)/emlx-$(EMLX_VERSION)-mlx-$(MLX_VERSION)$(MLX_VARIANT)-$(EMLX_NATIVE_SOURCE_HASH)/objs
 EMLX_SO = $(PRIV_DIR)/libemlx.so
 EMLX_LIB_DIR = $(PRIV_DIR)/mlx/lib
 # Headers are copied alongside the lib (unlike the lib copy, these are not
@@ -55,8 +55,8 @@ endif
 MAKE_JOBS ?= $(MAKE_DEFAULT_JOBS)
 
 # Source files
-SOURCES = c_src/emlx_nif.cpp c_src/emlx_fast.cpp c_src/emlx_fast/qwen3.cpp c_src/emlx_compiler.cpp c_src/emlx_plugin_registry.cpp
-HEADERS = c_src/nx_nif_utils.hpp c_src/emlx_worker.hpp c_src/emlx_async.hpp c_src/emlx_nif_shared.hpp c_src/emlx_plugin_registry.hpp c_src/emlx_fast/qwen3.hpp c_src/emlx_fast/qwen3_plugin_abi.hpp c_src/emlx_compiler.hpp c_src/emlx_runtime_call_bridge.hpp
+SOURCES = c_src/emlx_nif.cpp c_src/emlx_fast.cpp c_src/emlx_fast/qwen3.cpp c_src/emlx_fast/llama.cpp c_src/emlx_compiler.cpp c_src/emlx_plugin_registry.cpp
+HEADERS = c_src/nx_nif_utils.hpp c_src/emlx_worker.hpp c_src/emlx_async.hpp c_src/emlx_nif_shared.hpp c_src/emlx_plugin_registry.hpp c_src/emlx_fast/qwen3.hpp c_src/emlx_fast/qwen3_plugin_abi.hpp c_src/emlx_fast/llama.hpp c_src/emlx_fast/llama_plugin_abi.hpp c_src/emlx_compiler.hpp c_src/emlx_runtime_call_bridge.hpp
 OBJECTS = $(patsubst c_src/%.cpp,$(call esc,$(BUILD_DIR))/%.o,$(SOURCES))
 
 # Main targets

--- a/emlx/c_src/emlx_fast/llama.cpp
+++ b/emlx/c_src/emlx_fast/llama.cpp
@@ -1,0 +1,535 @@
+#include "llama.hpp"
+#include "../emlx_nif_shared.hpp"
+#include "../emlx_plugin_registry.hpp"
+#include "llama_plugin_abi.hpp"
+
+#include <memory>
+#include <stdexcept>
+
+static const emlx_llama_plugin::VTable *llama_plugin(ErlNifEnv *env, ERL_NIF_TERM *out_error) {
+  const void *vtable = emlx_get_plugin("llama");
+  if (vtable != nullptr) {
+    return reinterpret_cast<const emlx_llama_plugin::VTable *>(vtable);
+  }
+
+  *out_error =
+      nx::nif::error(env, "llama plugin not loaded — call EMLX.NIF.load_plugin(\"llama\", path) first");
+  return nullptr;
+}
+
+class LlamaTensorHandle {
+public:
+  explicit LlamaTensorHandle(mlx::core::array *ptr) : ptr_(ptr) {
+    refcount_ = reinterpret_cast<std::atomic<int> *>(ptr_ + 1);
+
+    if (refcount_->load() == 0) {
+      ptr_ = nullptr;
+      return;
+    }
+
+    ++(*refcount_);
+  }
+
+  ~LlamaTensorHandle() {
+    if (is_valid()) {
+      if (refcount_->fetch_sub(1) == 0) {
+        ptr_->~array();
+      }
+    }
+  }
+
+  bool is_valid() const { return ptr_ != nullptr; }
+  mlx::core::array *data() const { return ptr_; }
+
+private:
+  mlx::core::array *ptr_;
+  std::atomic<int> *refcount_;
+};
+
+using LlamaTensorHandles = std::vector<std::unique_ptr<LlamaTensorHandle>>;
+
+static bool llama_get_tensor(
+    ErlNifEnv *env,
+    ERL_NIF_TERM term,
+    mlx::core::array **out,
+    LlamaTensorHandles &handles,
+    ERL_NIF_TERM *error) {
+  mlx::core::array *raw = nullptr;
+
+  if (!enif_get_resource(
+          env, term, resource_object<mlx::core::array>::type,
+          reinterpret_cast<void **>(&raw))) {
+    return false;
+  }
+
+  auto handle = std::make_unique<LlamaTensorHandle>(raw);
+  if (!handle->is_valid()) {
+    *error = nx::nif::error(env, "Tensor has been deallocated");
+    return false;
+  }
+
+  *out = handle->data();
+  handles.push_back(std::move(handle));
+  return true;
+}
+
+static bool llama_get_tensor_or_device_ref(
+    ErlNifEnv *env,
+    ERL_NIF_TERM term,
+    mlx::core::array **out,
+    LlamaTensorHandles &handles,
+    ERL_NIF_TERM *error) {
+  if (llama_get_tensor(env, term, out, handles, error)) {
+    return true;
+  }
+  if (*error != 0) {
+    return false;
+  }
+
+  int arity = 0;
+  const ERL_NIF_TERM *items = nullptr;
+  if (!enif_get_tuple(env, term, &arity, &items) || arity != 2) {
+    return false;
+  }
+
+  return llama_get_tensor(env, items[1], out, handles, error);
+}
+
+static bool llama_get_layer(
+    ErlNifEnv *env,
+    ERL_NIF_TERM term,
+    emlx_llama_plugin::LayerParams &layer,
+    LlamaTensorHandles &handles,
+    ERL_NIF_TERM *error) {
+  int arity = 0;
+  const ERL_NIF_TERM *items = nullptr;
+  if (!enif_get_tuple(env, term, &arity, &items) || arity != 9) {
+    return false;
+  }
+
+  return llama_get_tensor(env, items[0], &layer.norm1, handles, error) &&
+         llama_get_tensor(env, items[1], &layer.norm2, handles, error) &&
+         llama_get_tensor(env, items[2], &layer.q_proj, handles, error) &&
+         llama_get_tensor(env, items[3], &layer.k_proj, handles, error) &&
+         llama_get_tensor(env, items[4], &layer.v_proj, handles, error) &&
+         llama_get_tensor(env, items[5], &layer.o_proj, handles, error) &&
+         llama_get_tensor(env, items[6], &layer.gate_proj, handles, error) &&
+         llama_get_tensor(env, items[7], &layer.up_proj, handles, error) &&
+         llama_get_tensor(env, items[8], &layer.down_proj, handles, error);
+}
+
+static bool llama_get_kv(
+    ErlNifEnv *env,
+    ERL_NIF_TERM term,
+    emlx_llama_plugin::KVCache &kv,
+    LlamaTensorHandles &handles,
+    ERL_NIF_TERM *error) {
+  int arity = 0;
+  const ERL_NIF_TERM *items = nullptr;
+  if (!enif_get_tuple(env, term, &arity, &items) || arity != 2) {
+    return false;
+  }
+
+  return llama_get_tensor_or_device_ref(env, items[0], &kv.k, handles, error) &&
+         llama_get_tensor_or_device_ref(env, items[1], &kv.v, handles, error);
+}
+
+static ERL_NIF_TERM llama_ref_error_or(
+    ErlNifEnv *env, ERL_NIF_TERM error, const char *fallback) {
+  if (error != 0) {
+    return error;
+  }
+
+  return nx::nif::error(env, fallback);
+}
+
+static bool llama_require_rank2_positive(
+    const mlx::core::array &tensor, const char *name, std::string &error) {
+  if (tensor.ndim() != 2) {
+    error = std::string(name) + " expects rank 2, got rank " + std::to_string(tensor.ndim());
+    return false;
+  }
+  if (tensor.shape(0) <= 0 || tensor.shape(1) <= 0) {
+    error = std::string(name) + " dimensions must be positive";
+    return false;
+  }
+  return true;
+}
+
+static bool llama_get_layers_and_kv(
+    ErlNifEnv *env,
+    ERL_NIF_TERM layers_arg,
+    ERL_NIF_TERM kv_arg,
+    std::vector<emlx_llama_plugin::LayerParams> &layers,
+    std::vector<emlx_llama_plugin::KVCache> &kvs,
+    LlamaTensorHandles &handles,
+    const char *context) {
+  unsigned int layer_count = 0;
+  unsigned int kv_count = 0;
+  if (!enif_get_list_length(env, layers_arg, &layer_count)) {
+    throw std::runtime_error(std::string(context) + " expects layers to be a list");
+  }
+  if (!enif_get_list_length(env, kv_arg, &kv_count)) {
+    throw std::runtime_error(std::string(context) + " expects kv_cache to be a list");
+  }
+  if (layer_count != kv_count) {
+    throw std::runtime_error(std::string(context) + " layers and kv_cache length mismatch");
+  }
+
+  ERL_NIF_TERM ref_error = 0;
+  layers.reserve(layer_count);
+  ERL_NIF_TERM layer_head, layer_tail = layers_arg;
+  while (enif_get_list_cell(env, layer_tail, &layer_head, &layer_tail)) {
+    emlx_llama_plugin::LayerParams layer;
+    if (!llama_get_layer(env, layer_head, layer, handles, &ref_error)) {
+      if (ref_error != 0) {
+        throw std::runtime_error("Tensor has been deallocated");
+      }
+      throw std::runtime_error(std::string(context) + " got invalid layer tuple");
+    }
+    layers.push_back(layer);
+  }
+
+  kvs.reserve(kv_count);
+  ERL_NIF_TERM kv_head, kv_tail = kv_arg;
+  while (enif_get_list_cell(env, kv_tail, &kv_head, &kv_tail)) {
+    emlx_llama_plugin::KVCache kv;
+    if (!llama_get_kv(env, kv_head, kv, handles, &ref_error)) {
+      if (ref_error != 0) {
+        throw std::runtime_error("Tensor has been deallocated");
+      }
+      throw std::runtime_error(std::string(context) + " got invalid kv_cache tuple");
+    }
+    kvs.push_back(kv);
+  }
+
+  return true;
+}
+
+static ERL_NIF_TERM llama_wrap_kv_terms(
+    ErlNifEnv *env, const std::vector<mlx::core::array> &k, const std::vector<mlx::core::array> &v) {
+  std::vector<ERL_NIF_TERM> kv_terms;
+  kv_terms.reserve(k.size());
+  for (size_t i = 0; i < k.size(); ++i) {
+    kv_terms.push_back(
+        enif_make_tuple2(env, create_tensor_resource(env, k[i]), create_tensor_resource(env, v[i])));
+  }
+  return enif_make_list_from_array(env, kv_terms.data(), kv_terms.size());
+}
+
+NIF(llama_layer) {
+  ERL_NIF_TERM plugin_error;
+  const emlx_llama_plugin::VTable *plugin = llama_plugin(env, &plugin_error);
+  if (plugin == nullptr) {
+    return plugin_error;
+  }
+
+  TENSOR_PARAM(0, hidden);
+  TENSOR_PARAM(1, norm1);
+  TENSOR_PARAM(2, q_proj);
+  TENSOR_PARAM(3, k_proj);
+  TENSOR_PARAM(4, v_proj);
+  TENSOR_PARAM(5, o_proj);
+  TENSOR_PARAM(6, k_cache);
+  TENSOR_PARAM(7, v_cache);
+  TENSOR_PARAM(8, norm2);
+  TENSOR_PARAM(9, gate_proj);
+  TENSOR_PARAM(10, up_proj);
+  TENSOR_PARAM(11, down_proj);
+  PARAM(12, int, offset);
+  PARAM(13, double, scale);
+  PARAM(14, int, head_dim);
+  TENSOR_PARAM(15, rope_freqs);
+  PARAM(16, double, eps);
+  DEVICE_PARAM(17, device);
+
+  try {
+    emlx_llama_plugin::LayerParams layer{
+        norm1, norm2, q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj};
+    emlx_llama_plugin::KVCache kv{k_cache, v_cache};
+
+    mlx::core::array out(0), k_upd(0), v_upd(0);
+    std::string error;
+    if (!plugin->layer_dense(
+            *hidden, layer, kv, offset, scale, head_dim, *rope_freqs, eps, device,
+            out, k_upd, v_upd, error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+
+    return nx::nif::ok(
+        env,
+        enif_make_tuple3(
+            env,
+            create_tensor_resource(env, out),
+            create_tensor_resource(env, k_upd),
+            create_tensor_resource(env, v_upd)));
+  }
+  CATCH()
+}
+ASYNC_NIF(llama_layer)
+
+NIF(llama_forward_greedy_ids) {
+  ERL_NIF_TERM plugin_error;
+  const emlx_llama_plugin::VTable *plugin = llama_plugin(env, &plugin_error);
+  if (plugin == nullptr) {
+    return plugin_error;
+  }
+
+  TENSOR_PARAM(0, input_ids);
+  TENSOR_PARAM(1, embed_tokens);
+  PARAM(6, int, offset);
+  PARAM(7, double, scale);
+  PARAM(8, int, head_dim);
+  TENSOR_PARAM(9, rope_freqs);
+  PARAM(10, double, eps);
+  DEVICE_PARAM(11, device);
+
+  try {
+    LlamaTensorHandles handles;
+    ERL_NIF_TERM ref_error = 0;
+    mlx::core::array *norm = nullptr;
+    mlx::core::array *lm_head = nullptr;
+    if (!llama_get_tensor(env, argv[4], &norm, handles, &ref_error)) {
+      return llama_ref_error_or(env, ref_error, "llama_forward_greedy_ids expects norm tensor ref");
+    }
+    if (!llama_get_tensor(env, argv[5], &lm_head, handles, &ref_error)) {
+      return llama_ref_error_or(env, ref_error, "llama_forward_greedy_ids expects lm_head tensor ref");
+    }
+
+    std::vector<emlx_llama_plugin::LayerParams> layers;
+    std::vector<emlx_llama_plugin::KVCache> kvs;
+    llama_get_layers_and_kv(env, argv[2], argv[3], layers, kvs, handles, "Llama greedy forward");
+
+    std::string error;
+    if (!llama_require_rank2_positive(*input_ids, "input_ids", error) ||
+        !llama_require_rank2_positive(*embed_tokens, "embed_tokens", error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+
+    int B = input_ids->shape(0);
+    int T = input_ids->shape(1);
+    auto ids = mlx::core::reshape(*input_ids, {B * T}, device);
+    auto embedded = mlx::core::reshape(
+        mlx::core::take(*embed_tokens, ids, 0, device), {B, T, embed_tokens->shape(1)}, device);
+
+    mlx::core::array token_out(0);
+    int64_t token_id_out = 0;
+    std::vector<mlx::core::array> k_out, v_out;
+    if (!plugin->forward_greedy_from_hidden(
+            embedded, layers, kvs, *norm, *lm_head, offset, scale, head_dim, *rope_freqs, eps,
+            false, device, token_out, token_id_out, k_out, v_out, error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+
+    return nx::nif::ok(
+        env,
+        enif_make_tuple2(env, create_tensor_resource(env, token_out), llama_wrap_kv_terms(env, k_out, v_out)));
+  }
+  CATCH()
+}
+ASYNC_NIF(llama_forward_greedy_ids)
+
+NIF(llama_forward_greedy_ids_token_id) {
+  ERL_NIF_TERM plugin_error;
+  const emlx_llama_plugin::VTable *plugin = llama_plugin(env, &plugin_error);
+  if (plugin == nullptr) {
+    return plugin_error;
+  }
+
+  TENSOR_PARAM(0, input_ids);
+  TENSOR_PARAM(1, embed_tokens);
+  PARAM(6, int, offset);
+  PARAM(7, double, scale);
+  PARAM(8, int, head_dim);
+  TENSOR_PARAM(9, rope_freqs);
+  PARAM(10, double, eps);
+  DEVICE_PARAM(11, device);
+
+  try {
+    LlamaTensorHandles handles;
+    ERL_NIF_TERM ref_error = 0;
+    mlx::core::array *norm = nullptr;
+    mlx::core::array *lm_head = nullptr;
+    if (!llama_get_tensor(env, argv[4], &norm, handles, &ref_error)) {
+      return llama_ref_error_or(env, ref_error, "llama_forward_greedy_ids_token_id expects norm tensor ref");
+    }
+    if (!llama_get_tensor(env, argv[5], &lm_head, handles, &ref_error)) {
+      return llama_ref_error_or(env, ref_error, "llama_forward_greedy_ids_token_id expects lm_head tensor ref");
+    }
+
+    std::vector<emlx_llama_plugin::LayerParams> layers;
+    std::vector<emlx_llama_plugin::KVCache> kvs;
+    llama_get_layers_and_kv(env, argv[2], argv[3], layers, kvs, handles, "Llama greedy forward");
+
+    std::string error;
+    if (!llama_require_rank2_positive(*input_ids, "input_ids", error) ||
+        !llama_require_rank2_positive(*embed_tokens, "embed_tokens", error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+
+    int B = input_ids->shape(0);
+    int T = input_ids->shape(1);
+    auto ids = mlx::core::reshape(*input_ids, {B * T}, device);
+    auto embedded = mlx::core::reshape(
+        mlx::core::take(*embed_tokens, ids, 0, device), {B, T, embed_tokens->shape(1)}, device);
+
+    mlx::core::array token_out(0);
+    int64_t token_id_out = 0;
+    std::vector<mlx::core::array> k_out, v_out;
+    if (!plugin->forward_greedy_from_hidden(
+            embedded, layers, kvs, *norm, *lm_head, offset, scale, head_dim, *rope_freqs, eps,
+            true, device, token_out, token_id_out, k_out, v_out, error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+
+    return nx::nif::ok(
+        env,
+        enif_make_tuple2(env, nx::nif::make(env, token_id_out), llama_wrap_kv_terms(env, k_out, v_out)));
+  }
+  CATCH()
+}
+ASYNC_NIF(llama_forward_greedy_ids_token_id)
+
+NIF(llama_forward_greedy_token_id) {
+  ERL_NIF_TERM plugin_error;
+  const emlx_llama_plugin::VTable *plugin = llama_plugin(env, &plugin_error);
+  if (plugin == nullptr) {
+    return plugin_error;
+  }
+
+  PARAM(0, int64_t, token_id);
+  TENSOR_PARAM(1, embed_tokens);
+  PARAM(6, int, offset);
+  PARAM(7, double, scale);
+  PARAM(8, int, head_dim);
+  TENSOR_PARAM(9, rope_freqs);
+  PARAM(10, double, eps);
+  DEVICE_PARAM(11, device);
+
+  try {
+    LlamaTensorHandles handles;
+    ERL_NIF_TERM ref_error = 0;
+    mlx::core::array *norm = nullptr;
+    mlx::core::array *lm_head = nullptr;
+    if (!llama_get_tensor(env, argv[4], &norm, handles, &ref_error)) {
+      return llama_ref_error_or(env, ref_error, "llama_forward_greedy_token_id expects norm tensor ref");
+    }
+    if (!llama_get_tensor(env, argv[5], &lm_head, handles, &ref_error)) {
+      return llama_ref_error_or(env, ref_error, "llama_forward_greedy_token_id expects lm_head tensor ref");
+    }
+    std::string error;
+    if (!llama_require_rank2_positive(*embed_tokens, "embed_tokens", error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+    if (token_id < 0 || token_id >= embed_tokens->shape(0)) {
+      return nx::nif::error(env, "token_id is outside the embedding vocabulary");
+    }
+
+    std::vector<emlx_llama_plugin::LayerParams> layers;
+    std::vector<emlx_llama_plugin::KVCache> kvs;
+    llama_get_layers_and_kv(env, argv[2], argv[3], layers, kvs, handles, "Llama greedy forward");
+
+    auto ids = mlx::core::array(token_id, mlx::core::int64);
+    auto embedded = mlx::core::reshape(
+        mlx::core::take(*embed_tokens, ids, 0, device), {1, 1, embed_tokens->shape(1)}, device);
+
+    mlx::core::array token_out(0);
+    int64_t token_id_out = 0;
+    std::vector<mlx::core::array> k_out, v_out;
+    if (!plugin->forward_greedy_from_hidden(
+            embedded, layers, kvs, *norm, *lm_head, offset, scale, head_dim, *rope_freqs, eps,
+            true, device, token_out, token_id_out, k_out, v_out, error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+
+    return nx::nif::ok(
+        env,
+        enif_make_tuple2(env, nx::nif::make(env, token_id_out), llama_wrap_kv_terms(env, k_out, v_out)));
+  }
+  CATCH()
+}
+ASYNC_NIF(llama_forward_greedy_token_id)
+
+NIF(llama_forward_greedy_ids_chunk) {
+  ERL_NIF_TERM plugin_error;
+  const emlx_llama_plugin::VTable *plugin = llama_plugin(env, &plugin_error);
+  if (plugin == nullptr) {
+    return plugin_error;
+  }
+
+  TENSOR_PARAM(0, input_ids);
+  TENSOR_PARAM(1, embed_tokens);
+  PARAM(6, int, offset);
+  PARAM(7, int, count);
+  PARAM(8, double, scale);
+  PARAM(9, int, head_dim);
+  TENSOR_PARAM(10, rope_freqs);
+  PARAM(11, double, eps);
+  DEVICE_PARAM(12, device);
+
+  try {
+    LlamaTensorHandles handles;
+    ERL_NIF_TERM ref_error = 0;
+    mlx::core::array *norm = nullptr;
+    mlx::core::array *lm_head = nullptr;
+    if (!llama_get_tensor(env, argv[4], &norm, handles, &ref_error)) {
+      return llama_ref_error_or(env, ref_error, "llama_forward_greedy_ids_chunk expects norm tensor ref");
+    }
+    if (!llama_get_tensor(env, argv[5], &lm_head, handles, &ref_error)) {
+      return llama_ref_error_or(env, ref_error, "llama_forward_greedy_ids_chunk expects lm_head tensor ref");
+    }
+
+    std::vector<emlx_llama_plugin::LayerParams> layers;
+    std::vector<emlx_llama_plugin::KVCache> kvs;
+    llama_get_layers_and_kv(env, argv[2], argv[3], layers, kvs, handles, "llama_forward_greedy_ids_chunk");
+
+    std::string error;
+    std::vector<mlx::core::array> token_out, k_out, v_out;
+    if (!plugin->forward_greedy_ids_chunk(
+            *input_ids, *embed_tokens, layers, kvs, *norm, *lm_head, offset, count,
+            scale, head_dim, *rope_freqs, eps, device, token_out, k_out, v_out, error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+
+    std::vector<ERL_NIF_TERM> token_terms;
+    token_terms.reserve(token_out.size());
+    for (const auto &token : token_out) {
+      token_terms.push_back(create_tensor_resource(env, token));
+    }
+
+    return nx::nif::ok(
+        env,
+        enif_make_tuple2(
+            env,
+            enif_make_list_from_array(env, token_terms.data(), token_terms.size()),
+            llama_wrap_kv_terms(env, k_out, v_out)));
+  }
+  CATCH()
+}
+ASYNC_NIF(llama_forward_greedy_ids_chunk)
+
+NIF(llama_final_greedy) {
+  ERL_NIF_TERM plugin_error;
+  const emlx_llama_plugin::VTable *plugin = llama_plugin(env, &plugin_error);
+  if (plugin == nullptr) {
+    return plugin_error;
+  }
+
+  TENSOR_PARAM(0, hidden);
+  TENSOR_PARAM(1, norm);
+  TENSOR_PARAM(2, lm_head);
+  PARAM(3, double, eps);
+  DEVICE_PARAM(4, device);
+
+  try {
+    mlx::core::array out(0);
+    std::string error;
+    if (!plugin->final_greedy(*hidden, *norm, *lm_head, eps, device, out, error)) {
+      return nx::nif::error(env, error.c_str());
+    }
+
+    TENSOR(out);
+  }
+  CATCH()
+}
+ASYNC_NIF(llama_final_greedy)

--- a/emlx/c_src/emlx_fast/llama.hpp
+++ b/emlx/c_src/emlx_fast/llama.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <erl_nif.h>
+
+ERL_NIF_TERM llama_layer_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM llama_forward_greedy_ids_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM llama_forward_greedy_ids_chunk_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM llama_forward_greedy_ids_token_id_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM llama_forward_greedy_token_id_async(ErlNifEnv *, int, const ERL_NIF_TERM []);
+ERL_NIF_TERM llama_final_greedy_async(ErlNifEnv *, int, const ERL_NIF_TERM []);

--- a/emlx/c_src/emlx_fast/llama_plugin_abi.hpp
+++ b/emlx/c_src/emlx_fast/llama_plugin_abi.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+// ABI shared between emlx's host NIF library and the standalone Llama compute
+// plugin built by emlx_axon.
+
+#include "mlx/mlx.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace emlx_llama_plugin {
+
+struct LayerParams {
+  mlx::core::array *norm1;
+  mlx::core::array *norm2;
+  mlx::core::array *q_proj;
+  mlx::core::array *k_proj;
+  mlx::core::array *v_proj;
+  mlx::core::array *o_proj;
+  mlx::core::array *gate_proj;
+  mlx::core::array *up_proj;
+  mlx::core::array *down_proj;
+};
+
+struct KVCache {
+  mlx::core::array *k;
+  mlx::core::array *v;
+};
+
+struct VTable {
+  bool (*layer_dense)(
+      const mlx::core::array &hidden, const LayerParams &layer, KVCache &kv,
+      int offset, double scale, int head_dim,
+      const mlx::core::array &rope_freqs, double eps,
+      const mlx::core::Device &device, mlx::core::array &out,
+      mlx::core::array &k_upd, mlx::core::array &v_upd,
+      std::string &error);
+
+  bool (*forward_greedy_from_hidden)(
+      const mlx::core::array &hidden, std::vector<LayerParams> &layers,
+      std::vector<KVCache> &kv, const mlx::core::array &norm,
+      const mlx::core::array &lm_head, int offset, double scale,
+      int head_dim, const mlx::core::array &rope_freqs, double eps,
+      bool return_token_id, const mlx::core::Device &device,
+      mlx::core::array &token_out, int64_t &token_id_out,
+      std::vector<mlx::core::array> &k_out,
+      std::vector<mlx::core::array> &v_out, std::string &error);
+
+  bool (*forward_greedy_ids_chunk)(
+      const mlx::core::array &input_ids, const mlx::core::array &embed_tokens,
+      std::vector<LayerParams> &layers, std::vector<KVCache> &initial_kv,
+      const mlx::core::array &norm, const mlx::core::array &lm_head,
+      int offset, int count, double scale, int head_dim,
+      const mlx::core::array &rope_freqs, double eps,
+      const mlx::core::Device &device,
+      std::vector<mlx::core::array> &token_out,
+      std::vector<mlx::core::array> &k_out,
+      std::vector<mlx::core::array> &v_out, std::string &error);
+
+  bool (*final_greedy)(
+      const mlx::core::array &hidden, const mlx::core::array &norm,
+      const mlx::core::array &lm_head, double eps,
+      const mlx::core::Device &device, mlx::core::array &out,
+      std::string &error);
+};
+
+} // namespace emlx_llama_plugin
+
+extern "C" const emlx_llama_plugin::VTable *emlx_plugin_vtable();

--- a/emlx/c_src/emlx_nif.cpp
+++ b/emlx/c_src/emlx_nif.cpp
@@ -1,5 +1,6 @@
 #include "emlx_compiler.hpp"
 #include "emlx_nif_shared.hpp"
+#include "emlx_fast/llama.hpp"
 #include "emlx_fast/qwen3.hpp"
 #include "emlx_plugin_registry.hpp"
 
@@ -2063,6 +2064,12 @@ static ErlNifFunc nif_funcs[] = {
     {"qwen3_final_greedy", 6, qwen3_final_greedy_async},
     {"qwen3_attention_residual", 5, qwen3_attention_residual_async},
     {"qwen3_attention_block", 17, qwen3_attention_block_async},
+    {"llama_layer", 19, llama_layer_async},
+    {"llama_forward_greedy_ids", 13, llama_forward_greedy_ids_async},
+    {"llama_forward_greedy_ids_chunk", 14, llama_forward_greedy_ids_chunk_async},
+    {"llama_forward_greedy_ids_token_id", 13, llama_forward_greedy_ids_token_id_async},
+    {"llama_forward_greedy_token_id", 13, llama_forward_greedy_token_id_async},
+    {"llama_final_greedy", 6, llama_final_greedy_async},
     // load_plugin `dlopen`s a named, standalone native plugin (see
     // emlx_plugin_registry.hpp); not worker-routed since it does no MLX
     // graph work.

--- a/emlx/lib/emlx/native/llama.ex
+++ b/emlx/lib/emlx/native/llama.ex
@@ -1,0 +1,319 @@
+defmodule EMLX.Native.Llama do
+  @moduledoc """
+  Fused native NIF wrappers for dense Llama transformer inference.
+
+  The C++ host side lives in `emlx/c_src/emlx_fast/llama.cpp` and dispatches
+  into the standalone Llama plugin loaded by `emlx_axon`.
+  """
+
+  import EMLX, only: [is_tensor: 2]
+
+  def layer(
+        {dev_h, ref_h},
+        {_dev_norm1, ref_norm1},
+        {_dev_q, ref_q},
+        {_dev_k, ref_k},
+        {_dev_v, ref_v},
+        {_dev_o, ref_o},
+        {_dev_kc, ref_kc},
+        {_dev_vc, ref_vc},
+        {_dev_norm2, ref_norm2},
+        {_dev_gate, ref_gate},
+        {_dev_up, ref_up},
+        {_dev_down, ref_down},
+        offset,
+        scale,
+        head_dim,
+        {dev_freqs, ref_freqs},
+        eps
+      )
+      when is_tensor(dev_h, ref_h) and is_integer(offset) and is_float(scale) and
+             is_integer(head_dim) and is_tensor(dev_freqs, ref_freqs) and is_float(eps) do
+    {worker, effective_device} = EMLX.resolve_worker(dev_h)
+
+    {out_ref, k_upd_ref, v_upd_ref} =
+      EMLX.NIF.llama_layer(
+        worker,
+        ref_h,
+        ref_norm1,
+        ref_q,
+        ref_k,
+        ref_v,
+        ref_o,
+        ref_kc,
+        ref_vc,
+        ref_norm2,
+        ref_gate,
+        ref_up,
+        ref_down,
+        offset,
+        scale,
+        head_dim,
+        ref_freqs,
+        eps,
+        effective_device
+      )
+      |> EMLX.unwrap!()
+      |> EMLX.await_worker()
+
+    {{effective_device, out_ref}, {effective_device, k_upd_ref}, {effective_device, v_upd_ref}}
+  end
+
+  def forward_greedy_ids(
+        {dev_ids, ref_ids},
+        {_dev_embed, ref_embed},
+        layers,
+        kv_cache,
+        {_dev_norm, ref_norm},
+        {_dev_lm_head, ref_lm_head},
+        offset,
+        scale,
+        head_dim,
+        {dev_freqs, ref_freqs},
+        eps
+      )
+      when is_tensor(dev_ids, ref_ids) and is_list(layers) and is_list(kv_cache) and
+             is_integer(offset) and is_float(scale) and is_integer(head_dim) and
+             is_tensor(dev_freqs, ref_freqs) and is_float(eps) do
+    {worker, effective_device} = EMLX.resolve_worker(dev_ids)
+    layer_refs = Enum.map(layers, &layer_refs!/1)
+    kv_refs = kv_refs(kv_cache)
+
+    {token_ref, kv_updated_refs} =
+      EMLX.NIF.llama_forward_greedy_ids(
+        worker,
+        ref_ids,
+        ref_embed,
+        layer_refs,
+        kv_refs,
+        ref_norm,
+        ref_lm_head,
+        offset,
+        scale,
+        head_dim,
+        ref_freqs,
+        eps,
+        effective_device
+      )
+      |> EMLX.unwrap!()
+      |> EMLX.await_worker()
+
+    {{effective_device, token_ref}, wrap_kv_cache(kv_updated_refs, effective_device)}
+  end
+
+  def forward_greedy_ids_chunk(
+        {dev_ids, ref_ids},
+        {_dev_embed, ref_embed},
+        layers,
+        kv_cache,
+        {_dev_norm, ref_norm},
+        {_dev_lm_head, ref_lm_head},
+        offset,
+        count,
+        scale,
+        head_dim,
+        {dev_freqs, ref_freqs},
+        eps
+      )
+      when is_tensor(dev_ids, ref_ids) and is_list(layers) and is_list(kv_cache) and
+             is_integer(offset) and is_integer(count) and count > 0 and is_float(scale) and
+             is_integer(head_dim) and is_tensor(dev_freqs, ref_freqs) and is_float(eps) do
+    {worker, effective_device} = EMLX.resolve_worker(dev_ids)
+    assert_decode_ids!({dev_ids, ref_ids}, "llama_forward_greedy_ids_chunk")
+    layer_refs = Enum.map(layers, &layer_refs!/1)
+    kv_refs = kv_refs(kv_cache)
+
+    {token_refs, kv_updated_refs} =
+      EMLX.NIF.llama_forward_greedy_ids_chunk(
+        worker,
+        ref_ids,
+        ref_embed,
+        layer_refs,
+        kv_refs,
+        ref_norm,
+        ref_lm_head,
+        offset,
+        count,
+        scale,
+        head_dim,
+        ref_freqs,
+        eps,
+        effective_device
+      )
+      |> EMLX.unwrap!()
+      |> EMLX.await_worker()
+
+    {Enum.map(token_refs, &{effective_device, &1}),
+     wrap_kv_cache(kv_updated_refs, effective_device)}
+  end
+
+  def forward_greedy_ids_token_id(
+        {dev_ids, ref_ids},
+        {_dev_embed, ref_embed},
+        layers,
+        kv_cache,
+        {_dev_norm, ref_norm},
+        {_dev_lm_head, ref_lm_head},
+        offset,
+        scale,
+        head_dim,
+        {dev_freqs, ref_freqs},
+        eps
+      )
+      when is_tensor(dev_ids, ref_ids) and is_list(layers) and is_list(kv_cache) and
+             is_integer(offset) and is_float(scale) and is_integer(head_dim) and
+             is_tensor(dev_freqs, ref_freqs) and is_float(eps) do
+    {worker, effective_device} = EMLX.resolve_worker(dev_ids)
+    assert_batch_size_one!({dev_ids, ref_ids}, "llama_forward_greedy_ids_token_id")
+    layer_refs = Enum.map(layers, &layer_refs!/1)
+    kv_refs = kv_refs(kv_cache)
+
+    {token_id, kv_updated_refs} =
+      EMLX.NIF.llama_forward_greedy_ids_token_id(
+        worker,
+        ref_ids,
+        ref_embed,
+        layer_refs,
+        kv_refs,
+        ref_norm,
+        ref_lm_head,
+        offset,
+        scale,
+        head_dim,
+        ref_freqs,
+        eps,
+        effective_device
+      )
+      |> EMLX.unwrap!()
+      |> EMLX.await_worker()
+
+    {token_id, wrap_kv_cache(kv_updated_refs, effective_device)}
+  end
+
+  def forward_greedy_token_id(
+        token_id,
+        {dev_embed, ref_embed},
+        layers,
+        kv_cache,
+        {_dev_norm, ref_norm},
+        {_dev_lm_head, ref_lm_head},
+        offset,
+        scale,
+        head_dim,
+        {dev_freqs, ref_freqs},
+        eps,
+        device \\ nil
+      )
+      when is_integer(token_id) and is_list(layers) and is_list(kv_cache) and
+             is_integer(offset) and is_float(scale) and is_integer(head_dim) and
+             is_tensor(dev_freqs, ref_freqs) and is_float(eps) do
+    device = device || dev_embed
+    {worker, effective_device} = EMLX.resolve_worker(device)
+    layer_refs = Enum.map(layers, &layer_refs!/1)
+    kv_refs = kv_refs(kv_cache)
+
+    {next_token_id, kv_updated_refs} =
+      EMLX.NIF.llama_forward_greedy_token_id(
+        worker,
+        token_id,
+        ref_embed,
+        layer_refs,
+        kv_refs,
+        ref_norm,
+        ref_lm_head,
+        offset,
+        scale,
+        head_dim,
+        ref_freqs,
+        eps,
+        effective_device
+      )
+      |> EMLX.unwrap!()
+      |> EMLX.await_worker()
+
+    {next_token_id, wrap_kv_cache(kv_updated_refs, effective_device)}
+  end
+
+  def final_greedy({dev_h, ref_h}, {_dev_norm, ref_norm}, {_dev_lm_head, ref_lm_head}, eps)
+      when is_tensor(dev_h, ref_h) and is_float(eps) do
+    {worker, effective_device} = EMLX.resolve_worker(dev_h)
+
+    out_ref =
+      EMLX.NIF.llama_final_greedy(worker, ref_h, ref_norm, ref_lm_head, eps, effective_device)
+      |> EMLX.unwrap!()
+      |> EMLX.await_worker()
+
+    {effective_device, out_ref}
+  end
+
+  defp layer_refs!({norm1, norm2, q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj}) do
+    {
+      tensor_ref!(norm1),
+      tensor_ref!(norm2),
+      tensor_ref!(q_proj),
+      tensor_ref!(k_proj),
+      tensor_ref!(v_proj),
+      tensor_ref!(o_proj),
+      tensor_ref!(gate_proj),
+      tensor_ref!(up_proj),
+      tensor_ref!(down_proj)
+    }
+  end
+
+  defp kv_refs!({{_device_k, ref_k}, {_device_v, ref_v}})
+       when is_reference(ref_k) and is_reference(ref_v),
+       do: {ref_k, ref_v}
+
+  defp kv_refs!({k_cache, v_cache}), do: {tensor_ref!(k_cache), tensor_ref!(v_cache)}
+
+  defp kv_refs([{{_device_k, ref_k}, {_device_v, ref_v}} | _rest] = kv_cache)
+       when is_reference(ref_k) and is_reference(ref_v),
+       do: kv_cache
+
+  defp kv_refs(kv_cache), do: Enum.map(kv_cache, &kv_refs!/1)
+
+  defp wrap_kv_cache(kv_refs, device) do
+    Enum.map(kv_refs, fn {k_ref, v_ref} -> {{device, k_ref}, {device, v_ref}} end)
+  end
+
+  defp assert_batch_size_one!(tensor, function_name) do
+    case EMLX.shape(tensor) do
+      {1, _seq_len} ->
+        :ok
+
+      {batch_size, _seq_len} ->
+        raise ArgumentError,
+              "#{function_name} requires batch size 1, got batch size #{batch_size}"
+
+      shape ->
+        raise ArgumentError,
+              "#{function_name} expects rank-2 input ids, got shape #{inspect(shape)}"
+    end
+  end
+
+  defp assert_decode_ids!(tensor, function_name) do
+    case EMLX.shape(tensor) do
+      {1, 1} ->
+        :ok
+
+      {1, seq_len} ->
+        raise ArgumentError,
+              "#{function_name} requires sequence length 1, got sequence length #{seq_len}"
+
+      {batch_size, _seq_len} ->
+        raise ArgumentError,
+              "#{function_name} requires batch size 1, got batch size #{batch_size}"
+
+      shape ->
+        raise ArgumentError,
+              "#{function_name} expects rank-2 input ids, got shape #{inspect(shape)}"
+    end
+  end
+
+  defp tensor_ref!(%Nx.Tensor{data: %EMLX.Backend{ref: {_device, ref}}}), do: ref
+
+  defp tensor_ref!(tensor) do
+    {_device, ref} = EMLX.Backend.from_nx(tensor)
+    ref
+  end
+end

--- a/emlx/lib/emlx/nif.ex
+++ b/emlx/lib/emlx/nif.ex
@@ -336,6 +336,111 @@ defmodule EMLX.NIF do
     :erlang.nif_error(:nif_not_loaded)
   end
 
+  # ── Llama fused native NIFs ────────────────────────────────────────────────
+  # Elixir wrappers live in `EMLX.Native.Llama`; the NIF/C++ names keep the
+  # `llama_` prefix (`emlx/c_src/emlx_fast/llama.cpp`).
+
+  def llama_layer(
+        _worker,
+        _hidden,
+        _norm1,
+        _q,
+        _k,
+        _v,
+        _o,
+        _k_cache,
+        _v_cache,
+        _norm2,
+        _gate,
+        _up,
+        _down,
+        _offset,
+        _scale,
+        _head_dim,
+        _rope_freqs,
+        _eps,
+        _device
+      ) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def llama_forward_greedy_ids(
+        _worker,
+        _ids,
+        _embed,
+        _layers,
+        _kv_cache,
+        _norm,
+        _lm_head,
+        _offset,
+        _scale,
+        _head_dim,
+        _rope_freqs,
+        _eps,
+        _device
+      ) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def llama_forward_greedy_ids_chunk(
+        _worker,
+        _ids,
+        _embed,
+        _layers,
+        _kv_cache,
+        _norm,
+        _lm_head,
+        _offset,
+        _count,
+        _scale,
+        _head_dim,
+        _rope_freqs,
+        _eps,
+        _device
+      ) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def llama_forward_greedy_ids_token_id(
+        _worker,
+        _ids,
+        _embed,
+        _layers,
+        _kv_cache,
+        _norm,
+        _lm_head,
+        _offset,
+        _scale,
+        _head_dim,
+        _rope_freqs,
+        _eps,
+        _device
+      ) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def llama_forward_greedy_token_id(
+        _worker,
+        _token_id,
+        _embed,
+        _layers,
+        _kv_cache,
+        _norm,
+        _lm_head,
+        _offset,
+        _scale,
+        _head_dim,
+        _rope_freqs,
+        _eps,
+        _device
+      ) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def llama_final_greedy(_worker, _hidden, _norm, _lm_head, _eps, _device) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
   # load_plugin — `dlopen`s a standalone, name-keyed native plugin (no
   # erl_nif dependency) and caches its vtable under `name` (see
   # emlx_plugin_registry.hpp). Callers that decode/dispatch into a

--- a/emlx/mix.exs
+++ b/emlx/mix.exs
@@ -5,6 +5,12 @@ defmodule EMLX.MixProject do
   @version "0.4.0"
   @mlx_version "0.31.2"
   @source_url "https://github.com/elixir-nx/emlx"
+  @native_source_patterns [
+    "Makefile",
+    "c_src/**/*.cpp",
+    "c_src/**/*.hpp",
+    "c_src/**/*.h"
+  ]
 
   require Logger
 
@@ -40,6 +46,7 @@ defmodule EMLX.MixProject do
           "MLX_VARIANT" => libmlx_config.variant,
           "EMLX_CACHE_DIR" => libmlx_config.cache_dir,
           "EMLX_VERSION" => @version,
+          "EMLX_NATIVE_SOURCE_HASH" => native_source_hash(),
           "LIBMLX_ENABLE_DEBUG" => to_string(libmlx_config.features.debug?),
           "FINE_INCLUDE_DIR" => Fine.include_dir()
         }
@@ -74,6 +81,38 @@ defmodule EMLX.MixProject do
       {:telemetry, "~> 1.0"},
       {:ex_doc, "~> 0.34", only: :docs}
     ]
+  end
+
+  defp native_source_hash do
+    case System.get_env("EMLX_NATIVE_SOURCE_HASH") do
+      nil -> compute_native_source_hash()
+      hash -> hash
+    end
+  end
+
+  defp compute_native_source_hash do
+    __DIR__
+    |> native_source_paths()
+    |> Enum.reduce(:crypto.hash_init(:sha256), fn path, ctx ->
+      relative = Path.relative_to(path, __DIR__)
+
+      ctx
+      |> :crypto.hash_update(relative)
+      |> :crypto.hash_update(<<0>>)
+      |> :crypto.hash_update(File.read!(path))
+      |> :crypto.hash_update(<<0>>)
+    end)
+    |> :crypto.hash_final()
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 12)
+  end
+
+  defp native_source_paths(root) do
+    @native_source_patterns
+    |> Enum.flat_map(&Path.wildcard(Path.join(root, &1)))
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.uniq()
+    |> Enum.sort()
   end
 
   defp docs do

--- a/emlx_axon/Makefile
+++ b/emlx_axon/Makefile
@@ -5,10 +5,10 @@ empty :=
 space := $(empty) $(empty)
 esc = $(subst $(space),\$(space),$(1))
 
-# Builds the standalone qwen3 compute plugin — pure MLX graph-building
-# code, no erl_nif dependency whatsoever (see c_src/qwen3_plugin.cpp and
-# emlx's c_src/emlx_fast/qwen3_plugin_abi.hpp). `dlopen`'d at runtime by
-# emlx's host NIF via `EMLX.NIF.load_plugin("qwen3", path)` — see
+# Builds standalone model compute plugins — pure MLX graph-building
+# code, no erl_nif dependency whatsoever (see c_src/*_plugin.cpp and
+# emlx's c_src/emlx_fast/*_plugin_abi.hpp). `dlopen`'d at runtime by
+# emlx's host NIF via `EMLX.NIF.load_plugin(name, path)` — see
 # lib/emlx_axon/application.ex.
 #
 # MLX_INCLUDE_DIR/MLX_LIB_DIR point at emlx's own already-resolved libmlx
@@ -17,8 +17,9 @@ esc = $(subst $(space),\$(space),$(1))
 # logic — see mix.exs's `make_env`.
 PRIV_DIR = $(MIX_APP_PATH)/priv
 QWEN3_SO = $(PRIV_DIR)/libemlx_qwen3.so
+LLAMA_SO = $(PRIV_DIR)/libemlx_llama.so
 
-CFLAGS = -fPIC -I$(call esc,$(MLX_INCLUDE_DIR)) -I$(call esc,$(QWEN3_ABI_INCLUDE_DIR)) -Wall -std=c++20 -O3
+CFLAGS = -fPIC -I$(call esc,$(MLX_INCLUDE_DIR)) -I$(call esc,$(QWEN3_ABI_INCLUDE_DIR)) -I$(call esc,$(LLAMA_ABI_INCLUDE_DIR)) -Wall -std=c++20 -O3
 LDFLAGS = -L$(call esc,$(MLX_LIB_DIR)) -lmlx -shared
 
 UNAME_S := $(shell uname -s)
@@ -29,17 +30,20 @@ else
     LDFLAGS += -Wl,-rpath,'$$ORIGIN/mlx/lib'
 endif
 
-SOURCES = c_src/qwen3_plugin.cpp
-HEADERS = $(call esc,$(QWEN3_ABI_INCLUDE_DIR))/qwen3_plugin_abi.hpp
-OBJECTS = $(patsubst c_src/%.cpp,$(call esc,$(PRIV_DIR))/objs/%.o,$(SOURCES))
+QWEN3_SOURCES = c_src/qwen3_plugin.cpp
+LLAMA_SOURCES = c_src/llama_plugin.cpp
+QWEN3_HEADERS = $(call esc,$(QWEN3_ABI_INCLUDE_DIR))/qwen3_plugin_abi.hpp
+LLAMA_HEADERS = $(call esc,$(LLAMA_ABI_INCLUDE_DIR))/llama_plugin_abi.hpp
+QWEN3_OBJECTS = $(patsubst c_src/%.cpp,$(call esc,$(PRIV_DIR))/objs/%.o,$(QWEN3_SOURCES))
+LLAMA_OBJECTS = $(patsubst c_src/%.cpp,$(call esc,$(PRIV_DIR))/objs/%.o,$(LLAMA_SOURCES))
 
-all: $(call esc,$(QWEN3_SO))
+all: $(call esc,$(QWEN3_SO)) $(call esc,$(LLAMA_SO))
 	@ echo > /dev/null
 
 $(call esc,$(PRIV_DIR)):
 	@ mkdir -p "$(PRIV_DIR)"
 
-$(call esc,$(PRIV_DIR))/objs/%.o: c_src/%.cpp $(HEADERS)
+$(call esc,$(PRIV_DIR))/objs/%.o: c_src/%.cpp $(QWEN3_HEADERS) $(LLAMA_HEADERS)
 	@ mkdir -p "$(dir $@)"
 	$(CXX) $(CFLAGS) -c "$<" -o "$@"
 
@@ -47,10 +51,15 @@ $(call esc,$(PRIV_DIR))/objs/%.o: c_src/%.cpp $(HEADERS)
 # already exist — this plugin's rpath (`@loader_path/mlx/lib`) resolves
 # relative to *its own* location, so we also copy the lib alongside it
 # here rather than relying on emlx's priv dir at runtime.
-$(call esc,$(QWEN3_SO)): $(call esc,$(PRIV_DIR)) $(OBJECTS)
+$(call esc,$(QWEN3_SO)): $(call esc,$(PRIV_DIR)) $(QWEN3_OBJECTS)
 	@ mkdir -p "$(PRIV_DIR)/mlx/lib"
 	@ cp -a "$(MLX_LIB_DIR)"/* "$(PRIV_DIR)/mlx/lib"
-	$(CXX) $(OBJECTS) -o "$(QWEN3_SO)" $(LDFLAGS)
+	$(CXX) $(QWEN3_OBJECTS) -o "$(QWEN3_SO)" $(LDFLAGS)
+
+$(call esc,$(LLAMA_SO)): $(call esc,$(PRIV_DIR)) $(LLAMA_OBJECTS)
+	@ mkdir -p "$(PRIV_DIR)/mlx/lib"
+	@ cp -a "$(MLX_LIB_DIR)"/* "$(PRIV_DIR)/mlx/lib"
+	$(CXX) $(LLAMA_OBJECTS) -o "$(LLAMA_SO)" $(LDFLAGS)
 
 clean:
 	rm -rf "$(PRIV_DIR)"

--- a/emlx_axon/bench/validate_llama_dense.exs
+++ b/emlx_axon/bench/validate_llama_dense.exs
@@ -1,0 +1,629 @@
+# emlx_axon/bench/validate_llama_dense.exs
+#
+# Dense Llama benchmark for standard Hugging Face safetensors checkpoints.
+# Measures stock Bumblebee + EMLX, the EMLXAxon rewrite path, and the native
+# EMLXAxon Llama dense path when available.
+#
+# Run from emlx_axon:
+#
+#   EMLX_DENSE_LLAMA_MODEL=meta-llama/Llama-3.2-1B \
+#   EMLX_DENSE_LLAMA_DEVICE=gpu \
+#   EMLX_DENSE_LLAMA_TYPE=f16 \
+#   EMLX_DENSE_LLAMA_SEQUENCE_LENGTH=128 \
+#   EMLX_DENSE_LLAMA_MAX_NEW=32 \
+#   EMLX_DENSE_LLAMA_RUNS=3 \
+#   EMLX_DENSE_LLAMA_WARMUP_RUNS=1 \
+#   EMLX_DENSE_LLAMA_STRICT_LENGTH=false \
+#   EMLX_DENSE_LLAMA_JSON=/tmp/llama_dense_baseline.json \
+#     mix run bench/validate_llama_dense.exs
+
+defmodule LlamaDenseBenchmark do
+  @moduledoc false
+
+  def run do
+    config = config()
+    Nx.default_backend({EMLX.Backend, device: config.device})
+
+    IO.puts("""
+    === emlx_axon/bench/validate_llama_dense.exs ===
+    purpose:          validate dense Llama paths
+    model:            #{config.model_ref}
+    model_source:     #{inspect(model_source_label(config.model_ref))}
+    branch:           #{git(["branch", "--show-current"])}
+    commit:           #{git(["rev-parse", "--short", "HEAD"])}
+    machine:          #{machine()}
+    device:           #{config.device}
+    type:             #{config.type}
+    sequence_length:  #{config.sequence_length}
+    max_new_tokens:   #{config.max_new_tokens}
+    warmup_runs:      #{config.warmup_runs}
+    measured_runs:    #{config.runs}
+    strict_length:    #{config.strict_length?}
+    auth_token:       #{if config.auth_token, do: "present", else: "absent"}
+    native_llama:     #{if llama_native_exports() == [], do: "unavailable", else: "available"}
+    """)
+
+    load_result = timed(fn -> load_model(config) end)
+
+    {:ok, model_info, tokenizer, generation_config} =
+      case load_result.value do
+        {:ok, model_info, tokenizer, generation_config} ->
+          {:ok, model_info, tokenizer, generation_config}
+
+        {:error, reason} ->
+          report_load_error(config, load_result.ms, reason)
+      end
+
+    spec = model_info.spec
+    generation_config = configure_generation(generation_config, model_info, config)
+
+    IO.puts(
+      "loaded model in #{format_ms(load_result.ms)} ms " <>
+        "spec=#{inspect(spec.__struct__)} arch=#{inspect(spec.architecture)}"
+    )
+
+    rewrite_result = timed(fn -> EMLXAxon.rewrite(model_info.model) end)
+    rewrite_model_info = %{model_info | model: rewrite_result.value}
+    IO.puts("rewrote model in #{format_ms(rewrite_result.ms)} ms")
+
+    stock =
+      benchmark_path(
+        "stock",
+        build_serving(model_info, tokenizer, generation_config, config),
+        config
+      )
+
+    rewrite =
+      benchmark_path(
+        "rewrite",
+        build_serving(rewrite_model_info, tokenizer, generation_config, config),
+        config
+      )
+
+    native_llama =
+      benchmark_native_llama(model_info, tokenizer, generation_config, config)
+
+    report = %{
+      benchmark: "llama_dense_hf_safetensors",
+      purpose: "validate dense Llama paths",
+      branch: git(["branch", "--show-current"]),
+      commit: git(["rev-parse", "--short", "HEAD"]),
+      machine: machine(),
+      model: config.model_ref,
+      model_source: inspect(model_source_label(config.model_ref)),
+      dense_safetensors?: dense_safetensors?(config.model_ref),
+      device: config.device,
+      type: config.type,
+      precision: config.type,
+      quantization_bits: nil,
+      sequence_length: config.sequence_length,
+      max_new_tokens: config.max_new_tokens,
+      strict_length?: config.strict_length?,
+      warmup_runs: config.warmup_runs,
+      measured_runs: config.runs,
+      prompt: config.prompt,
+      load_ms: round_float(load_result.ms),
+      rewrite_ms: round_float(rewrite_result.ms),
+      paths: %{
+        stock: stock,
+        rewrite: rewrite,
+        native_llama: native_llama
+      },
+      speedups: speedups(stock, rewrite, native_llama),
+      verification:
+        verification(%{stock: stock, rewrite: rewrite, native_llama: native_llama}, config)
+    }
+
+    print_summary(report)
+    maybe_write_json(config.json_path, report)
+    enforce_strict_length!(report, config)
+  end
+
+  defp config do
+    %{
+      model_ref: System.get_env("EMLX_DENSE_LLAMA_MODEL", "meta-llama/Llama-3.2-1B"),
+      device: parse_device(System.get_env("EMLX_DENSE_LLAMA_DEVICE", "gpu")),
+      type: parse_type(System.get_env("EMLX_DENSE_LLAMA_TYPE", "f16")),
+      sequence_length: parse_pos_int("EMLX_DENSE_LLAMA_SEQUENCE_LENGTH", 128),
+      max_new_tokens: parse_pos_int("EMLX_DENSE_LLAMA_MAX_NEW", 32),
+      runs: parse_pos_int("EMLX_DENSE_LLAMA_RUNS", 3),
+      warmup_runs: parse_non_neg_int("EMLX_DENSE_LLAMA_WARMUP_RUNS", 1),
+      strict_length?: parse_bool("EMLX_DENSE_LLAMA_STRICT_LENGTH", false),
+      auth_token:
+        System.get_env("EMLX_DENSE_LLAMA_AUTH_TOKEN") ||
+          System.get_env("HF_TOKEN") ||
+          System.get_env("HUGGINGFACE_TOKEN"),
+      prompt:
+        System.get_env(
+          "EMLX_DENSE_LLAMA_PROMPT",
+          "Write one short sentence about native Elixir inference."
+        ),
+      json_path: System.get_env("EMLX_DENSE_LLAMA_JSON")
+    }
+  end
+
+  defp load_model(config) do
+    source = model_source(config)
+
+    with {:ok, model_info} <-
+           Bumblebee.load_model(source,
+             type: config.type,
+             backend: {EMLX.Backend, device: config.device}
+           ),
+         {:ok, tokenizer} <- Bumblebee.load_tokenizer(source),
+         {:ok, generation_config} <- Bumblebee.load_generation_config(source) do
+      generation_config =
+        Bumblebee.configure(generation_config,
+          max_new_tokens: config.max_new_tokens,
+          strategy: %{type: :greedy_search}
+        )
+
+      {:ok, model_info, tokenizer, generation_config}
+    end
+  end
+
+  defp configure_generation(generation_config, _model_info, %{strict_length?: false}) do
+    generation_config
+  end
+
+  defp configure_generation(generation_config, model_info, %{strict_length?: true}) do
+    impossible_eos = strict_eos_token_id(model_info)
+
+    Bumblebee.configure(generation_config,
+      eos_token_id: impossible_eos,
+      forced_eos_token_id: nil
+    )
+  end
+
+  defp strict_eos_token_id(%{spec: %{vocab_size: vocab_size}}) when is_integer(vocab_size) do
+    vocab_size + 1_000
+  end
+
+  defp report_load_error(config, load_ms, reason) do
+    message = Exception.message(RuntimeError.exception(inspect(reason)))
+
+    IO.puts("""
+
+    === Dense Llama Baseline Unavailable ===
+    load_ms: #{format_ms(load_ms)}
+    reason:  #{message}
+
+    The requested model could not be loaded. If this is a gated Meta Llama
+    checkpoint, authenticate with Hugging Face or pass EMLX_DENSE_LLAMA_MODEL
+    as a local cached Llama 3.2 1B snapshot path.
+    """)
+
+    report = %{
+      benchmark: "llama_dense_hf_safetensors_baseline",
+      purpose: "baseline before native Llama accelerator work",
+      status: "model_unavailable",
+      branch: git(["branch", "--show-current"]),
+      commit: git(["rev-parse", "--short", "HEAD"]),
+      machine: machine(),
+      model: config.model_ref,
+      model_source: inspect(model_source_label(config.model_ref)),
+      device: config.device,
+      type: config.type,
+      precision: config.type,
+      sequence_length: config.sequence_length,
+      max_new_tokens: config.max_new_tokens,
+      strict_length?: config.strict_length?,
+      warmup_runs: config.warmup_runs,
+      measured_runs: config.runs,
+      prompt: config.prompt,
+      load_ms: round_float(load_ms),
+      error: message,
+      verification: %{
+        native_llama_exports: llama_native_exports(),
+        native_llama_available?: llama_native_exports() != []
+      }
+    }
+
+    maybe_write_json(config.json_path, report)
+    System.halt(1)
+  end
+
+  defp build_serving(model_info, tokenizer, generation_config, config) do
+    Bumblebee.Text.generation(model_info, tokenizer, generation_config,
+      compile: [batch_size: 1, sequence_length: config.sequence_length],
+      defn_options: [compiler: EMLX, device: config.device],
+      preallocate_params: true
+    )
+  end
+
+  defp benchmark_path(label, serving, config) do
+    IO.puts("\n==> #{label}: warmup")
+
+    warmups =
+      for i <- run_indices(config.warmup_runs) do
+        result = run_once(serving, config.prompt, config.max_new_tokens)
+        IO.puts("  warmup #{i}: #{result.tokens} tokens / #{format_ms(result.ms)} ms")
+        result
+      end
+
+    IO.puts("==> #{label}: measured")
+
+    runs =
+      for i <- run_indices(config.runs) do
+        result = run_once(serving, config.prompt, config.max_new_tokens)
+
+        IO.puts(
+          "  run #{i}: #{result.tokens} tokens / #{format_ms(result.ms)} ms = " <>
+            "#{format_rate(result.tok_s)} tok/s finish=#{result.finish_reason}"
+        )
+
+        result
+      end
+
+    path_report(warmups, runs)
+  end
+
+  defp benchmark_native_llama(model_info, tokenizer, generation_config, config) do
+    IO.puts("\n==> native_llama: build state")
+
+    if config.device != :gpu do
+      skipped_path("native Llama benchmark requires EMLX_DENSE_LLAMA_DEVICE=gpu")
+      |> Map.put(:native_used?, false)
+    else
+      case EMLXAxon.Llama.DenseLoader.from_model_info(model_info,
+             generation_config: generation_config
+           ) do
+        {:ok, state} ->
+          try do
+            serving =
+              EMLXAxon.TextGeneration.serving(tokenizer, state,
+                max_new_tokens: config.max_new_tokens,
+                max_len: config.sequence_length + config.max_new_tokens,
+                sampler: :greedy,
+                host_sync: native_host_sync(config)
+              )
+
+            benchmark_path("native_llama", serving, config)
+            |> Map.put(:native_used?, true)
+          rescue
+            exception ->
+              skipped_path(Exception.message(exception))
+              |> Map.put(:native_used?, false)
+          end
+
+        {:error, reason} ->
+          skipped_path(inspect(reason))
+          |> Map.put(:native_used?, false)
+      end
+    end
+  end
+
+  defp native_host_sync(%{strict_length?: true}), do: :end
+  defp native_host_sync(config), do: {:chunk, min(config.max_new_tokens, 31)}
+
+  defp run_once(serving, prompt, max_new_tokens) do
+    result = timed(fn -> Nx.Serving.run(serving, prompt) end)
+    {text, tokens, finish_reason} = extract_text_tokens_finish(result.value, max_new_tokens)
+    public_run(result.ms, tokens, finish_reason, text)
+  end
+
+  defp extract_text_tokens_finish(%{results: [%{text: text, token_summary: summary}]}, max_new_tokens) do
+    {text, summary.output, inferred_finish_reason(summary.output, max_new_tokens)}
+  end
+
+  defp extract_text_tokens_finish(%{
+         results: [%{generated_text: text, num_tokens: tokens}],
+         finish_reason: finish_reason
+       }, _max_new_tokens) do
+    {text, tokens, finish_reason}
+  end
+
+  defp extract_text_tokens_finish(
+         %{results: [%{generated_text: text, num_tokens: tokens}]},
+         max_new_tokens
+       ) do
+    {text, tokens, inferred_finish_reason(tokens, max_new_tokens)}
+  end
+
+  defp inferred_finish_reason(tokens, max_new_tokens) when tokens >= max_new_tokens, do: :length
+  defp inferred_finish_reason(_tokens, _max_new_tokens), do: :stop
+
+  defp public_run(ms, tokens, finish_reason, text) do
+    %{
+      ms: ms,
+      tokens: tokens,
+      tok_s: rate(tokens, ms),
+      finish_reason: finish_reason,
+      preview: text |> String.replace("\n", " ") |> String.slice(0, 80)
+    }
+  end
+
+  defp path_report(warmups, runs) do
+    %{
+      warmup: summarize(warmups),
+      measured: summarize(runs),
+      runs: Enum.map(runs, &json_run/1)
+    }
+  end
+
+  defp summarize([]), do: stats([])
+
+  defp summarize(runs) do
+    %{
+      duration_ms: stats(Enum.map(runs, & &1.ms)),
+      tokens: stats(Enum.map(runs, & &1.tokens)),
+      tokens_per_sec: stats(Enum.map(runs, & &1.tok_s)),
+      finish_reasons: Enum.frequencies(Enum.map(runs, &to_string(&1.finish_reason)))
+    }
+  end
+
+  defp stats([]), do: %{count: 0}
+
+  defp stats(values) do
+    sorted = Enum.sort(values)
+    count = length(sorted)
+
+    %{
+      count: count,
+      min: round_float(List.first(sorted)),
+      p50: round_float(percentile(sorted, 0.50)),
+      p95: round_float(percentile(sorted, 0.95)),
+      max: round_float(List.last(sorted)),
+      mean: round_float(Enum.sum(values) / count)
+    }
+  end
+
+  defp skipped_path(reason) do
+    %{
+      skipped: true,
+      reason: reason,
+      warmup: stats([]),
+      measured: %{
+        duration_ms: stats([]),
+        tokens: stats([]),
+        tokens_per_sec: stats([]),
+        finish_reasons: %{"skipped" => 1}
+      },
+      runs: []
+    }
+  end
+
+  defp speedups(stock, rewrite, native_llama) do
+    stock_tps = get_in(stock, [:measured, :tokens_per_sec, :p50]) || 0.0
+    rewrite_tps = get_in(rewrite, [:measured, :tokens_per_sec, :p50]) || 0.0
+    native_tps = get_in(native_llama, [:measured, :tokens_per_sec, :p50]) || 0.0
+
+    %{
+      rewrite_vs_stock: ratio(rewrite_tps, stock_tps),
+      native_llama_vs_stock: ratio(native_tps, stock_tps),
+      native_llama_vs_rewrite: ratio(native_tps, rewrite_tps)
+    }
+  end
+
+  defp verification(paths, config) do
+    measured_token_counts =
+      Map.new(paths, fn {path, path_report} ->
+        {path, Enum.map(path_report[:runs] || [], & &1.tokens)}
+      end)
+
+    finish_reasons =
+      Map.new(paths, fn {path, path_report} ->
+        {path, get_in(path_report, [:measured, :finish_reasons]) || %{}}
+      end)
+
+    %{
+      native_llama_exports: llama_native_exports(),
+      native_llama_available?: llama_native_exports() != [],
+      strict_length?: config.strict_length?,
+      expected_tokens_per_run: config.max_new_tokens,
+      measured_token_counts: measured_token_counts,
+      equal_measured_token_count?: equal_measured_token_count?(measured_token_counts, config),
+      finish_reasons: finish_reasons,
+      comparable_finish_reasons?: comparable_finish_reasons?(finish_reasons, config)
+    }
+  end
+
+  defp equal_measured_token_count?(measured_token_counts, config) do
+    measured_token_counts
+    |> Map.values()
+    |> Enum.all?(&(&1 == List.duplicate(config.max_new_tokens, config.runs)))
+  end
+
+  defp comparable_finish_reasons?(finish_reasons, %{strict_length?: true, runs: runs}) do
+    Enum.all?(finish_reasons, fn {_path, reasons} -> reasons == %{"length" => runs} end)
+  end
+
+  defp comparable_finish_reasons?(finish_reasons, _config) do
+    finish_reasons
+    |> Map.values()
+    |> Enum.uniq()
+    |> length()
+    |> Kernel.==(1)
+  end
+
+  defp enforce_strict_length!(_report, %{strict_length?: false}), do: :ok
+
+  defp enforce_strict_length!(report, %{strict_length?: true}) do
+    verification = report.verification
+
+    unless verification.equal_measured_token_count? and verification.comparable_finish_reasons? do
+      raise """
+      strict Llama dense benchmark failed validation:
+        measured_token_counts=#{inspect(verification.measured_token_counts)}
+        finish_reasons=#{inspect(verification.finish_reasons)}
+      """
+    end
+  end
+
+  defp print_summary(report) do
+    IO.puts("\n=== Dense Llama Baseline Summary ===")
+
+    Enum.each([:stock, :rewrite, :native_llama], fn path ->
+      path_report = report.paths[path]
+
+      if path_report[:skipped] do
+        IO.puts("#{path}: skipped (#{path_report.reason})")
+      else
+        measured = path_report.measured
+
+        IO.puts(
+          "#{path}: duration_p50=#{measured.duration_ms.p50} ms " <>
+            "tok/s_p50=#{measured.tokens_per_sec.p50} " <>
+            "tokens_p50=#{measured.tokens.p50} " <>
+            "finish=#{inspect(measured.finish_reasons)}"
+        )
+      end
+    end)
+
+    IO.puts("speedups: #{inspect(report.speedups)}")
+  end
+
+  defp maybe_write_json(nil, _report), do: :ok
+
+  defp maybe_write_json(path, report) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, Jason.encode!(report, pretty: true))
+    IO.puts("json_output: #{path}")
+  end
+
+  defp model_source(%{model_ref: path_or_repo, auth_token: auth_token}) do
+    expanded = Path.expand(path_or_repo)
+
+    cond do
+      File.dir?(expanded) -> {:local, expanded}
+      auth_token -> {:hf, path_or_repo, auth_token: auth_token}
+      true -> {:hf, path_or_repo}
+    end
+  end
+
+  defp model_source_label(path_or_repo) do
+    expanded = Path.expand(path_or_repo)
+
+    if File.dir?(expanded), do: {:local, expanded}, else: {:hf, path_or_repo}
+  end
+
+  defp dense_safetensors?(model_ref) do
+    expanded = Path.expand(model_ref)
+
+    File.dir?(expanded) and
+      expanded
+      |> File.ls!()
+      |> Enum.any?(&String.ends_with?(&1, ".safetensors"))
+  rescue
+    _ -> false
+  end
+
+  defp llama_native_exports do
+    EMLX.Native.Llama.module_info(:exports)
+    |> Enum.map(fn {name, arity} -> "#{name}/#{arity}" end)
+    |> Enum.reject(&(String.starts_with?(&1, "__") or String.starts_with?(&1, "module_info/")))
+    |> Enum.sort()
+  end
+
+  defp parse_device("gpu"), do: :gpu
+  defp parse_device("cpu"), do: :cpu
+
+  defp parse_device(other) do
+    raise ArgumentError,
+          "expected EMLX_DENSE_LLAMA_DEVICE to be gpu or cpu, got: #{inspect(other)}"
+  end
+
+  defp parse_type("f16"), do: :f16
+  defp parse_type("bf16"), do: :bf16
+  defp parse_type("f32"), do: :f32
+
+  defp parse_type(other) do
+    raise ArgumentError,
+          "expected EMLX_DENSE_LLAMA_TYPE to be f16, bf16, or f32, got: #{inspect(other)}"
+  end
+
+  defp parse_pos_int(env, default) do
+    value = System.get_env(env, Integer.to_string(default)) |> String.to_integer()
+    if value > 0, do: value, else: raise(ArgumentError, "#{env} must be positive")
+  end
+
+  defp parse_non_neg_int(env, default) do
+    value = System.get_env(env, Integer.to_string(default)) |> String.to_integer()
+    if value >= 0, do: value, else: raise(ArgumentError, "#{env} must be non-negative")
+  end
+
+  defp parse_bool(env, default) do
+    case System.get_env(env) do
+      nil -> default
+      "true" -> true
+      "false" -> false
+      other -> raise ArgumentError, "#{env} must be true or false, got: #{inspect(other)}"
+    end
+  end
+
+  defp run_indices(0), do: []
+  defp run_indices(n), do: 1..n
+
+  defp timed(fun) do
+    start = System.monotonic_time(:native)
+    value = fun.()
+    stop = System.monotonic_time(:native)
+    %{value: value, ms: System.convert_time_unit(stop - start, :native, :microsecond) / 1000.0}
+  end
+
+  defp rate(tokens, ms) when ms > 0, do: tokens / ms * 1000.0
+  defp rate(_tokens, _ms), do: 0.0
+
+  defp ratio(_num, den) when den == 0.0, do: nil
+  defp ratio(num, den), do: round_float(num / den)
+
+  defp percentile(sorted, pct) do
+    idx = max(0, min(length(sorted) - 1, ceil(length(sorted) * pct) - 1))
+    Enum.at(sorted, idx)
+  end
+
+  defp round_float(value) when is_integer(value), do: value
+  defp round_float(value) when is_float(value), do: Float.round(value, 3)
+
+  defp format_ms(ms), do: :erlang.float_to_binary(ms / 1.0, decimals: 1)
+  defp format_rate(rate), do: :erlang.float_to_binary(rate / 1.0, decimals: 1)
+
+  defp json_run(run) do
+    %{
+      duration_ms: round_float(run.ms),
+      tokens: run.tokens,
+      tokens_per_sec: round_float(run.tok_s),
+      finish_reason: to_string(run.finish_reason),
+      preview: run.preview
+    }
+  end
+
+  defp git(args) do
+    case System.cmd("git", args, stderr_to_stdout: true) do
+      {output, 0} -> String.trim(output)
+      {_output, _status} -> nil
+    end
+  end
+
+  defp machine do
+    cpu = sysctl("machdep.cpu.brand_string")
+    mem = sysctl("hw.memsize") |> parse_mem()
+
+    [cpu, mem]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(", ")
+  end
+
+  defp sysctl(key) do
+    case System.cmd("sysctl", ["-n", key], stderr_to_stdout: true) do
+      {output, 0} -> String.trim(output)
+      {_output, _status} -> nil
+    end
+  end
+
+  defp parse_mem(nil), do: nil
+
+  defp parse_mem(bytes) do
+    gb =
+      bytes
+      |> String.to_integer()
+      |> Kernel./(1024 * 1024 * 1024)
+      |> Float.round(1)
+
+    "#{gb} GB RAM"
+  rescue
+    _ -> nil
+  end
+end
+
+LlamaDenseBenchmark.run()

--- a/emlx_axon/c_src/llama_plugin.cpp
+++ b/emlx_axon/c_src/llama_plugin.cpp
@@ -1,0 +1,588 @@
+#include "llama_plugin_abi.hpp"
+
+#include <limits>
+#include <sstream>
+
+using namespace emlx_llama_plugin;
+
+namespace {
+
+mlx::core::Shape to_shape(std::initializer_list<int> v) {
+  return mlx::core::Shape(v.begin(), v.end());
+}
+
+bool check_rank(const mlx::core::array &tensor, int expected, const char *name,
+                 std::string &error) {
+  if (tensor.ndim() != expected) {
+    std::ostringstream msg;
+    msg << name << " expects rank " << expected << ", got rank " << tensor.ndim();
+    error = msg.str();
+    return false;
+  }
+  return true;
+}
+
+bool check_positive(int value, const char *name, std::string &error) {
+  if (value <= 0) {
+    error = std::string(name) + " must be positive";
+    return false;
+  }
+  return true;
+}
+
+bool check_non_negative(int value, const char *name, std::string &error) {
+  if (value < 0) {
+    error = std::string(name) + " must be non-negative";
+    return false;
+  }
+  return true;
+}
+
+bool check_dim(const mlx::core::array &tensor, int axis, int expected,
+                const char *name, const char *dim_name, std::string &error) {
+  if (tensor.shape(axis) != expected) {
+    std::ostringstream msg;
+    msg << name << " " << dim_name << " must be " << expected
+        << ", got " << tensor.shape(axis);
+    error = msg.str();
+    return false;
+  }
+  return true;
+}
+
+bool check_rank_positive(const mlx::core::array &tensor, int rank,
+                          const char *name, std::string &error) {
+  if (!check_rank(tensor, rank, name, error)) {
+    return false;
+  }
+  for (int axis = 0; axis < rank; ++axis) {
+    if (tensor.shape(axis) <= 0) {
+      error = std::string(name) + " dimensions must be positive";
+      return false;
+    }
+  }
+  return true;
+}
+
+bool check_rank4_positive(const mlx::core::array &t, const char *n, std::string &e) {
+  return check_rank_positive(t, 4, n, e);
+}
+
+bool check_rank3_positive(const mlx::core::array &t, const char *n, std::string &e) {
+  return check_rank_positive(t, 3, n, e);
+}
+
+bool check_rank2_positive(const mlx::core::array &t, const char *n, std::string &e) {
+  return check_rank_positive(t, 2, n, e);
+}
+
+bool check_rank1_dim(const mlx::core::array &tensor, int expected,
+                      const char *name, std::string &error) {
+  if (!check_rank(tensor, 1, name, error)) {
+    return false;
+  }
+  return check_dim(tensor, 0, expected, name, "size", error);
+}
+
+bool validate_projection_width(const mlx::core::array &projection, int input_width,
+                                int head_dim, const char *name, std::string &error) {
+  if (!check_rank2_positive(projection, name, error)) {
+    return false;
+  }
+  if (!check_dim(projection, 0, input_width, name, "input width", error)) {
+    return false;
+  }
+  if ((projection.shape(1) % head_dim) != 0) {
+    error = std::string(name) + " output width must be divisible by head_dim";
+    return false;
+  }
+  return true;
+}
+
+bool validate_rope_freqs(const mlx::core::array &rope_freqs, int head_dim,
+                          std::string &error) {
+  if ((head_dim % 2) != 0) {
+    error = "head_dim must be even for Llama RoPE frequencies";
+    return false;
+  }
+  return check_rank1_dim(rope_freqs, head_dim / 2, "rope_freqs", error);
+}
+
+bool validate_kv_cache_bn(const mlx::core::array &k_cache,
+                           const mlx::core::array &v_cache, int batch,
+                           int num_kv_heads, int offset, int token_count,
+                           int head_dim, std::string &error) {
+  if (!check_rank4_positive(k_cache, "k_cache", error) ||
+      !check_rank4_positive(v_cache, "v_cache", error)) {
+    return false;
+  }
+  if (!check_dim(k_cache, 0, batch, "k_cache", "batch", error) ||
+      !check_dim(v_cache, 0, batch, "v_cache", "batch", error) ||
+      !check_dim(k_cache, 1, num_kv_heads, "k_cache", "heads", error) ||
+      !check_dim(v_cache, 1, num_kv_heads, "v_cache", "heads", error) ||
+      !check_dim(k_cache, 3, head_dim, "k_cache", "head_dim", error) ||
+      !check_dim(v_cache, 3, head_dim, "v_cache", "head_dim", error)) {
+    return false;
+  }
+  if (v_cache.shape(2) != k_cache.shape(2)) {
+    error = "k_cache and v_cache capacity must match";
+    return false;
+  }
+
+  int64_t required_len = static_cast<int64_t>(offset) + static_cast<int64_t>(token_count);
+  int capacity = k_cache.shape(2);
+  if (required_len > capacity) {
+    std::ostringstream msg;
+    msg << "KV cache capacity " << capacity << " is smaller than required length "
+        << required_len;
+    error = msg.str();
+    return false;
+  }
+  return true;
+}
+
+mlx::core::array apply_rope(const mlx::core::array &a, int head_dim, int offset,
+                             const mlx::core::array &rope_freqs,
+                             const mlx::core::Device &device) {
+  auto offsets = mlx::core::full({a.shape(0)}, offset, mlx::core::int32, device);
+  return mlx::core::fast::rope(
+      a, head_dim, false, std::nullopt, 1.0f, offsets, rope_freqs, device);
+}
+
+mlx::core::array linear_in_out(const mlx::core::array &x, const mlx::core::array &weight,
+                                const mlx::core::Device &device) {
+  if (x.ndim() == 3 && x.shape(1) == 1) {
+    auto x_2d = mlx::core::reshape(x, {x.shape(0), x.shape(2)}, device);
+    auto out = mlx::core::matmul(x_2d, weight, device);
+    return mlx::core::reshape(out, {x.shape(0), 1, weight.shape(1)}, device);
+  }
+  return mlx::core::matmul(x, weight, device);
+}
+
+mlx::core::array linear_out_in(const mlx::core::array &x, const mlx::core::array &weight,
+                                const mlx::core::Device &device) {
+  return mlx::core::tensordot(
+      x, weight, std::vector<int>{static_cast<int>(x.ndim()) - 1}, std::vector<int>{1}, device);
+}
+
+int64_t token_to_int64(mlx::core::array &token) {
+  mlx::core::eval(token);
+  auto dtype = token.dtype();
+  if (dtype == mlx::core::uint8) return static_cast<int64_t>(token.item<uint8_t>());
+  if (dtype == mlx::core::uint16) return static_cast<int64_t>(token.item<uint16_t>());
+  if (dtype == mlx::core::uint32) return static_cast<int64_t>(token.item<uint32_t>());
+  if (dtype == mlx::core::uint64) return static_cast<int64_t>(token.item<uint64_t>());
+  if (dtype == mlx::core::int8) return static_cast<int64_t>(token.item<int8_t>());
+  if (dtype == mlx::core::int16) return static_cast<int64_t>(token.item<int16_t>());
+  if (dtype == mlx::core::int32) return static_cast<int64_t>(token.item<int32_t>());
+  return token.item<int64_t>();
+}
+
+bool validate_dense_layer(const mlx::core::array &hidden, const LayerParams &layer,
+                           const KVCache &kv, const mlx::core::array &rope_freqs,
+                           int offset, int head_dim, std::string &error) {
+  if (!check_rank3_positive(hidden, "hidden", error) ||
+      !check_non_negative(offset, "offset", error) ||
+      !check_positive(head_dim, "head_dim", error)) {
+    return false;
+  }
+
+  int B = hidden.shape(0);
+  int T_new = hidden.shape(1);
+  int H = hidden.shape(2);
+  int D = head_dim;
+
+  if (!check_rank1_dim(*layer.norm1, H, "norm1", error) ||
+      !check_rank1_dim(*layer.norm2, H, "norm2", error) ||
+      !validate_projection_width(*layer.q_proj, H, D, "q_proj", error) ||
+      !validate_projection_width(*layer.k_proj, H, D, "k_proj", error) ||
+      !validate_projection_width(*layer.v_proj, H, D, "v_proj", error) ||
+      !check_dim(*layer.v_proj, 1, layer.k_proj->shape(1), "v_proj", "output width", error)) {
+    return false;
+  }
+
+  int N_q = layer.q_proj->shape(1) / D;
+  int N_kv = layer.k_proj->shape(1) / D;
+  int attn_width = N_q * D;
+  if ((N_q % N_kv) != 0) {
+    error = "query heads must be divisible by key/value heads";
+    return false;
+  }
+
+  if (!check_rank2_positive(*layer.o_proj, "o_proj", error) ||
+      !check_dim(*layer.o_proj, 0, attn_width, "o_proj", "input width", error) ||
+      !check_dim(*layer.o_proj, 1, H, "o_proj", "output width", error) ||
+      !validate_kv_cache_bn(*kv.k, *kv.v, B, N_kv, offset, T_new, D, error) ||
+      !validate_rope_freqs(rope_freqs, D, error) ||
+      !check_rank2_positive(*layer.gate_proj, "gate_proj", error) ||
+      !check_rank2_positive(*layer.up_proj, "up_proj", error) ||
+      !check_rank2_positive(*layer.down_proj, "down_proj", error) ||
+      !check_dim(*layer.gate_proj, 0, H, "gate_proj", "input width", error) ||
+      !check_dim(*layer.up_proj, 0, H, "up_proj", "input width", error) ||
+      !check_dim(*layer.up_proj, 1, layer.gate_proj->shape(1), "up_proj", "output width", error) ||
+      !check_dim(*layer.down_proj, 0, layer.gate_proj->shape(1), "down_proj", "input width", error) ||
+      !check_dim(*layer.down_proj, 1, H, "down_proj", "output width", error)) {
+    return false;
+  }
+
+  return true;
+}
+
+mlx::core::array build_prefill_mask(const mlx::core::array &q, int T_new, int valid_len,
+                                     const mlx::core::Device &device) {
+  auto mask_dtype = q.dtype();
+  auto zero_val = mlx::core::zeros({}, mask_dtype, device);
+  auto neginf_val = mlx::core::full({}, -std::numeric_limits<float>::infinity(), mask_dtype, device);
+  int kv_offset = valid_len - T_new;
+  auto row = mlx::core::reshape(
+      mlx::core::arange(T_new, mlx::core::int32, device), {1, 1, T_new, 1}, device);
+  auto col = mlx::core::reshape(
+      mlx::core::arange(valid_len, mlx::core::int32, device), {1, 1, 1, valid_len}, device);
+  auto causal_bool = mlx::core::less_equal(
+      col, mlx::core::add(row, mlx::core::array(kv_offset, mlx::core::int32), device), device);
+  return mlx::core::where(causal_bool, zero_val, neginf_val, device);
+}
+
+mlx::core::array sdpa(const mlx::core::array &q_rope, const mlx::core::array &k_valid,
+                       const mlx::core::array &v_valid, float scale, int T_new,
+                       int valid_len, const mlx::core::Device &device) {
+  return (T_new == 1)
+             ? mlx::core::fast::scaled_dot_product_attention(
+                   q_rope, k_valid, v_valid, scale, "", std::nullopt, std::nullopt, device)
+             : mlx::core::fast::scaled_dot_product_attention(
+                   q_rope, k_valid, v_valid, scale, "array",
+                   build_prefill_mask(q_rope, T_new, valid_len, device), std::nullopt, device);
+}
+
+mlx::core::array layer_dense_impl(const mlx::core::array &hidden, const LayerParams &layer,
+                                   KVCache &kv, int offset, float scale, int head_dim,
+                                   const mlx::core::array &rope_freqs, float eps,
+                                   const mlx::core::Device &device, mlx::core::array *k_out,
+                                   mlx::core::array *v_out) {
+  int B = hidden.shape(0);
+  int T_new = hidden.shape(1);
+  int D = head_dim;
+  int N_q = layer.q_proj->shape(1) / D;
+  int N_kv = layer.k_proj->shape(1) / D;
+  int attn_width = N_q * D;
+  int valid_len = offset + T_new;
+
+  auto xn = mlx::core::fast::rms_norm(hidden, *layer.norm1, eps, device);
+  auto q_flat = linear_in_out(xn, *layer.q_proj, device);
+  auto k_flat = linear_in_out(xn, *layer.k_proj, device);
+  auto v_flat = linear_in_out(xn, *layer.v_proj, device);
+
+  auto q = mlx::core::reshape(q_flat, {B, T_new, N_q, D}, device);
+  auto k = mlx::core::reshape(k_flat, {B, T_new, N_kv, D}, device);
+  auto v = mlx::core::reshape(v_flat, {B, T_new, N_kv, D}, device);
+
+  auto q_bn = mlx::core::transpose(q, {0, 2, 1, 3}, device);
+  auto k_bn = mlx::core::transpose(k, {0, 2, 1, 3}, device);
+  auto v_bn = mlx::core::transpose(v, {0, 2, 1, 3}, device);
+
+  auto q_rope = apply_rope(q_bn, D, offset, rope_freqs, device);
+  auto k_rope = apply_rope(k_bn, D, offset, rope_freqs, device);
+
+  auto k_cache_owned = std::move(*kv.k);
+  auto v_cache_owned = std::move(*kv.v);
+
+  auto k_upd = mlx::core::slice_update(
+      k_cache_owned, k_rope, to_shape({0, 0, offset, 0}), to_shape({B, N_kv, valid_len, D}), device);
+  auto v_upd = mlx::core::slice_update(
+      v_cache_owned, v_bn, to_shape({0, 0, offset, 0}), to_shape({B, N_kv, valid_len, D}), device);
+
+  auto k_valid = mlx::core::slice(k_upd, to_shape({0, 0, 0, 0}), to_shape({B, N_kv, valid_len, D}), device);
+  auto v_valid = mlx::core::slice(v_upd, to_shape({0, 0, 0, 0}), to_shape({B, N_kv, valid_len, D}), device);
+
+  auto attn_out_bn = sdpa(q_rope, k_valid, v_valid, scale, T_new, valid_len, device);
+  auto attn_out_bthd = mlx::core::transpose(attn_out_bn, {0, 2, 1, 3}, device);
+  auto attn_out = mlx::core::reshape(attn_out_bthd, {B, T_new, attn_width}, device);
+  auto attn_projected = linear_in_out(attn_out, *layer.o_proj, device);
+  auto attn_hidden = mlx::core::add(hidden, attn_projected, device);
+
+  auto xn2 = mlx::core::fast::rms_norm(attn_hidden, *layer.norm2, eps, device);
+  auto gate = linear_in_out(xn2, *layer.gate_proj, device);
+  auto up = linear_in_out(xn2, *layer.up_proj, device);
+  auto mlp = mlx::core::multiply(
+      mlx::core::multiply(gate, mlx::core::sigmoid(gate, device), device), up, device);
+  auto mlp_out = linear_in_out(mlp, *layer.down_proj, device);
+
+  if (k_out != nullptr) {
+    *k_out = k_upd;
+  }
+  if (v_out != nullptr) {
+    *v_out = v_upd;
+  }
+
+  return mlx::core::add(attn_hidden, mlp_out, device);
+}
+
+bool v_layer_dense(const mlx::core::array &hidden, const LayerParams &layer, KVCache &kv,
+                    int offset, double scale, int head_dim, const mlx::core::array &rope_freqs,
+                    double eps, const mlx::core::Device &device, mlx::core::array &out,
+                    mlx::core::array &k_upd, mlx::core::array &v_upd, std::string &error) {
+  try {
+    if (!validate_dense_layer(hidden, layer, kv, rope_freqs, offset, head_dim, error)) {
+      return false;
+    }
+    out = layer_dense_impl(
+        hidden, layer, kv, offset, static_cast<float>(scale), head_dim, rope_freqs,
+        static_cast<float>(eps), device, &k_upd, &v_upd);
+    return true;
+  } catch (const std::exception &e) {
+    error = e.what();
+    return false;
+  } catch (...) {
+    error = "Unknown error in llama plugin layer_dense";
+    return false;
+  }
+}
+
+bool v_forward_greedy_from_hidden(
+    const mlx::core::array &hidden, std::vector<LayerParams> &layers,
+    std::vector<KVCache> &kv, const mlx::core::array &norm,
+    const mlx::core::array &lm_head, int offset, double scale, int head_dim,
+    const mlx::core::array &rope_freqs, double eps, bool return_token_id,
+    const mlx::core::Device &device, mlx::core::array &token_out, int64_t &token_id_out,
+    std::vector<mlx::core::array> &k_out, std::vector<mlx::core::array> &v_out,
+    std::string &error) {
+  try {
+    if (layers.size() != kv.size()) {
+      error = "Llama greedy forward layers and kv_cache length mismatch";
+      return false;
+    }
+    if (!check_rank3_positive(hidden, "hidden", error) ||
+        !check_non_negative(offset, "offset", error) ||
+        !check_positive(head_dim, "head_dim", error)) {
+      return false;
+    }
+
+    auto current = hidden;
+    k_out.clear();
+    v_out.clear();
+    k_out.reserve(layers.size());
+    v_out.reserve(layers.size());
+    std::vector<mlx::core::array> eval_arrays;
+    eval_arrays.reserve((layers.size() * 2) + 1);
+
+    for (size_t i = 0; i < layers.size(); ++i) {
+      if (!validate_dense_layer(current, layers[i], kv[i], rope_freqs, offset, head_dim, error)) {
+        return false;
+      }
+
+      mlx::core::array k_new = *kv[i].k;
+      mlx::core::array v_new = *kv[i].v;
+      current = layer_dense_impl(
+          current, layers[i], kv[i], offset, static_cast<float>(scale), head_dim, rope_freqs,
+          static_cast<float>(eps), device, &k_new, &v_new);
+      eval_arrays.push_back(k_new);
+      eval_arrays.push_back(v_new);
+      k_out.push_back(k_new);
+      v_out.push_back(v_new);
+    }
+
+    int B = current.shape(0);
+    int T = current.shape(1);
+    int H = current.shape(2);
+    if (return_token_id && B != 1) {
+      error = "token_id return paths require batch size 1";
+      return false;
+    }
+    if (!check_rank1_dim(norm, H, "norm", error) ||
+        !check_rank2_positive(lm_head, "lm_head", error) ||
+        !check_dim(lm_head, 1, H, "lm_head", "hidden width", error)) {
+      return false;
+    }
+
+    auto last = (T == 1)
+                    ? mlx::core::reshape(current, {B, H}, device)
+                    : mlx::core::reshape(
+                          mlx::core::slice(current, to_shape({0, T - 1, 0}), to_shape({B, T, H}), device),
+                          {B, H}, device);
+
+    auto normed = mlx::core::fast::rms_norm(last, norm, static_cast<float>(eps), device);
+    auto logits = linear_out_in(normed, lm_head, device);
+    auto token = mlx::core::argmax(logits, 1, false, device);
+
+    eval_arrays.push_back(token);
+    mlx::core::async_eval(eval_arrays);
+
+    if (return_token_id) {
+      token_id_out = token_to_int64(token);
+    } else {
+      token_out = token;
+    }
+    return true;
+  } catch (const std::exception &e) {
+    error = e.what();
+    return false;
+  } catch (...) {
+    error = "Unknown error in llama plugin forward_greedy_from_hidden";
+    return false;
+  }
+}
+
+bool v_forward_greedy_ids_chunk(
+    const mlx::core::array &input_ids, const mlx::core::array &embed_tokens,
+    std::vector<LayerParams> &layers, std::vector<KVCache> &initial_kv,
+    const mlx::core::array &norm, const mlx::core::array &lm_head,
+    int offset, int count, double scale, int head_dim,
+    const mlx::core::array &rope_freqs, double eps, const mlx::core::Device &device,
+    std::vector<mlx::core::array> &token_out, std::vector<mlx::core::array> &k_out,
+    std::vector<mlx::core::array> &v_out, std::string &error) {
+  try {
+    if (count <= 0) {
+      error = "llama_forward_greedy_ids_chunk expects positive count";
+      return false;
+    }
+    if (layers.size() != initial_kv.size()) {
+      error = "llama_forward_greedy_ids_chunk layers and kv_cache length mismatch";
+      return false;
+    }
+    if (!check_rank2_positive(input_ids, "input_ids", error) ||
+        !check_rank2_positive(embed_tokens, "embed_tokens", error) ||
+        !check_non_negative(offset, "offset", error) ||
+        !check_positive(head_dim, "head_dim", error) ||
+        !check_rank1_dim(norm, embed_tokens.shape(1), "norm", error) ||
+        !check_rank2_positive(lm_head, "lm_head", error) ||
+        !check_dim(lm_head, 1, embed_tokens.shape(1), "lm_head", "hidden width", error)) {
+      return false;
+    }
+    if (input_ids.shape(0) != 1) {
+      error = "llama_forward_greedy_ids_chunk requires batch size 1";
+      return false;
+    }
+    if (input_ids.shape(1) != 1) {
+      error = "llama_forward_greedy_ids_chunk requires sequence length 1";
+      return false;
+    }
+
+    std::vector<mlx::core::array> k_cache;
+    std::vector<mlx::core::array> v_cache;
+    std::vector<mlx::core::array> next_k_cache;
+    std::vector<mlx::core::array> next_v_cache;
+    std::vector<mlx::core::array> token_arrays;
+    k_cache.reserve(layers.size());
+    v_cache.reserve(layers.size());
+    next_k_cache.reserve(layers.size());
+    next_v_cache.reserve(layers.size());
+    token_arrays.reserve(count);
+
+    auto current_ids = input_ids;
+    int current_offset = offset;
+
+    for (int step = 0; step < count; ++step) {
+      int B = current_ids.shape(0);
+      int T = current_ids.shape(1);
+      auto ids = mlx::core::reshape(current_ids, {B * T}, device);
+      auto current = mlx::core::reshape(
+          mlx::core::take(embed_tokens, ids, 0, device), {B, T, embed_tokens.shape(1)}, device);
+
+      next_k_cache.clear();
+      next_v_cache.clear();
+
+      for (size_t layer_idx = 0; layer_idx < layers.size(); ++layer_idx) {
+        KVCache kv = (step == 0) ? initial_kv[layer_idx]
+                                  : KVCache{&k_cache[layer_idx], &v_cache[layer_idx]};
+        if (!validate_dense_layer(current, layers[layer_idx], kv, rope_freqs, current_offset,
+                                   head_dim, error)) {
+          return false;
+        }
+
+        mlx::core::array k_new = *kv.k;
+        mlx::core::array v_new = *kv.v;
+        current = layer_dense_impl(
+            current, layers[layer_idx], kv, current_offset, static_cast<float>(scale), head_dim,
+            rope_freqs, static_cast<float>(eps), device, &k_new, &v_new);
+        next_k_cache.push_back(k_new);
+        next_v_cache.push_back(v_new);
+      }
+
+      int B_out = current.shape(0);
+      int T_out = current.shape(1);
+      int H_out = current.shape(2);
+      auto last =
+          (T_out == 1)
+              ? mlx::core::reshape(current, {B_out, H_out}, device)
+              : mlx::core::reshape(
+                    mlx::core::slice(current, to_shape({0, T_out - 1, 0}), to_shape({B_out, T_out, H_out}), device),
+                    {B_out, H_out}, device);
+
+      auto normed = mlx::core::fast::rms_norm(last, norm, static_cast<float>(eps), device);
+      auto logits = linear_out_in(normed, lm_head, device);
+      auto token = mlx::core::argmax(logits, 1, false, device);
+      token_arrays.push_back(token);
+      current_ids = mlx::core::reshape(token, {B_out, 1}, device);
+      k_cache.swap(next_k_cache);
+      v_cache.swap(next_v_cache);
+      current_offset += 1;
+    }
+
+    std::vector<mlx::core::array> eval_arrays;
+    eval_arrays.reserve(token_arrays.size() + (layers.size() * 2));
+    eval_arrays.insert(eval_arrays.end(), token_arrays.begin(), token_arrays.end());
+    for (size_t layer_idx = 0; layer_idx < layers.size(); ++layer_idx) {
+      eval_arrays.push_back(k_cache[layer_idx]);
+      eval_arrays.push_back(v_cache[layer_idx]);
+    }
+    mlx::core::async_eval(eval_arrays);
+
+    token_out = std::move(token_arrays);
+    k_out = std::move(k_cache);
+    v_out = std::move(v_cache);
+    return true;
+  } catch (const std::exception &e) {
+    error = e.what();
+    return false;
+  } catch (...) {
+    error = "Unknown error in llama plugin forward_greedy_ids_chunk";
+    return false;
+  }
+}
+
+bool v_final_greedy(const mlx::core::array &hidden, const mlx::core::array &norm,
+                     const mlx::core::array &lm_head, double eps,
+                     const mlx::core::Device &device, mlx::core::array &out,
+                     std::string &error) {
+  try {
+    if (!check_rank3_positive(hidden, "hidden", error)) {
+      return false;
+    }
+    int B = hidden.shape(0);
+    int T = hidden.shape(1);
+    int H = hidden.shape(2);
+    if (!check_rank1_dim(norm, H, "norm", error) ||
+        !check_rank2_positive(lm_head, "lm_head", error) ||
+        !check_dim(lm_head, 1, H, "lm_head", "hidden width", error)) {
+      return false;
+    }
+
+    auto last = (T == 1)
+                    ? mlx::core::reshape(hidden, {B, H}, device)
+                    : mlx::core::reshape(
+                          mlx::core::slice(hidden, to_shape({0, T - 1, 0}), to_shape({B, T, H}), device),
+                          {B, H}, device);
+    auto normed = mlx::core::fast::rms_norm(last, norm, static_cast<float>(eps), device);
+    auto logits = linear_out_in(normed, lm_head, device);
+    out = mlx::core::argmax(logits, 1, false, device);
+    return true;
+  } catch (const std::exception &e) {
+    error = e.what();
+    return false;
+  } catch (...) {
+    error = "Unknown error in llama plugin final_greedy";
+    return false;
+  }
+}
+
+const VTable VTABLE = {
+    v_layer_dense,
+    v_forward_greedy_from_hidden,
+    v_forward_greedy_ids_chunk,
+    v_final_greedy};
+
+} // namespace
+
+extern "C" const emlx_llama_plugin::VTable *emlx_plugin_vtable() {
+  return &VTABLE;
+}

--- a/emlx_axon/lib/emlx_axon/application.ex
+++ b/emlx_axon/lib/emlx_axon/application.ex
@@ -2,9 +2,8 @@ defmodule EMLXAxon.Application do
   @moduledoc """
   OTP Application for EMLXAxon.
 
-  Eagerly loads the standalone qwen3 compute plugin (`c_src/qwen3_plugin.cpp`,
-  built as `priv/libemlx_qwen3.so`) into emlx's generic native plugin
-  registry via `EMLX.NIF.load_plugin/2`. Every `EMLX.Native.Qwen3.*` NIF
+  Eagerly loads standalone model compute plugins into emlx's generic native
+  plugin registry via `EMLX.NIF.load_plugin/2`. Every `EMLX.Native.*` model NIF
   errors with `{:error, _}` until this has run — since `:emlx` is a
   dependency of `:emlx_axon`, OTP starts it first, so `EMLX.NIF.load_plugin/2`
   is always available by the time this runs.
@@ -15,20 +14,31 @@ defmodule EMLXAxon.Application do
   @doc false
   def start(_type, _args) do
     ensure_qwen3_plugin_loaded!()
+    ensure_llama_plugin_loaded!()
     Supervisor.start_link([], strategy: :one_for_one, name: __MODULE__)
   end
 
   @doc false
   def ensure_qwen3_plugin_loaded! do
-    path = :filename.join(:code.priv_dir(:emlx_axon), ~c"libemlx_qwen3.so")
+    ensure_plugin_loaded!("qwen3", ~c"libemlx_qwen3.so")
+  end
 
-    case EMLX.NIF.load_plugin("qwen3", List.to_string(path)) do
+  @doc false
+  def ensure_llama_plugin_loaded! do
+    ensure_plugin_loaded!("llama", ~c"libemlx_llama.so")
+  end
+
+  defp ensure_plugin_loaded!(name, lib_name) do
+    path = :filename.join(:code.priv_dir(:emlx_axon), lib_name)
+
+    case EMLX.NIF.load_plugin(name, List.to_string(path)) do
       :ok ->
         :ok
 
       {:error, reason} ->
         raise EMLX.NIFError,
-              "EMLXAxon.Application could not load the qwen3 plugin: " <> List.to_string(reason)
+              "EMLXAxon.Application could not load the #{name} plugin: " <>
+                List.to_string(reason)
     end
   end
 end

--- a/emlx_axon/lib/emlx_axon/llama/dense_loader.ex
+++ b/emlx_axon/lib/emlx_axon/llama/dense_loader.ex
@@ -1,0 +1,406 @@
+defmodule EMLXAxon.Llama.DenseLoader do
+  @moduledoc """
+  Builds native Llama `%EMLXAxon.Llama.Model.State{}` structs from standard
+  Bumblebee Llama dense parameters or Hugging Face safetensors files.
+
+  Bumblebee stores dense linear kernels in `{in, out}` convention. The native
+  dense Llama bridge keeps that layout so MLX can use direct
+  `matmul(input, weight)` calls without adding a transpose node for every
+  projection in the decode graph.
+  """
+
+  alias EMLXAxon.Llama.{Model, Rope}
+  alias EMLXAxon.Llama.Model.State
+
+  @gpu {EMLX.Backend, device: :gpu}
+
+  @doc """
+  Converts a Bumblebee Llama `model_info` map into a native dense state.
+
+  ## Options
+
+    * `:generation_config` - a `%Bumblebee.Text.GenerationConfig{}` returned by
+      `Bumblebee.load_generation_config/2`. Its `:eos_token_id` and
+      `:bos_token_id` fields are copied into the native state.
+
+    * `:eos_token_id` - overrides the EOS token id. Accepts a non-negative
+      integer or a non-empty list of non-negative integers.
+
+    * `:bos_token_id` - overrides the BOS token id. Accepts a non-negative
+      integer or a non-empty list of non-negative integers.
+  """
+  @spec from_model_info(map()) :: {:ok, State.t()} | {:error, term()}
+  @spec from_model_info(map(), keyword()) :: {:ok, State.t()} | {:error, term()}
+  def from_model_info(model_info, opts \\ [])
+
+  def from_model_info(%{params: %{data: params}, spec: %Bumblebee.Text.Llama{} = spec}, opts)
+      when is_list(opts) do
+    opts = Keyword.validate!(opts, [:generation_config, :eos_token_id, :bos_token_id])
+    config = config_from_spec(spec, opts)
+
+    layers =
+      for i <- 0..(config.num_hidden_layers - 1) do
+        block = "decoder.blocks.#{i}"
+
+        Model.layer(
+          tensor!(params, "#{block}.self_attention_norm", "weight"),
+          tensor!(params, "#{block}.output_norm", "weight"),
+          tensor!(params, "#{block}.self_attention.query", "kernel"),
+          tensor!(params, "#{block}.self_attention.key", "kernel"),
+          tensor!(params, "#{block}.self_attention.value", "kernel"),
+          tensor!(params, "#{block}.self_attention.output", "kernel"),
+          tensor!(params, "#{block}.ffn.gate", "kernel"),
+          tensor!(params, "#{block}.ffn.intermediate", "kernel"),
+          tensor!(params, "#{block}.ffn.output", "kernel")
+        )
+      end
+
+    embed_tokens = tensor!(params, "embedder.token_embedding", "kernel")
+    norm = tensor!(params, "output_norm", "weight")
+    lm_head = tensor!(params, "language_modeling_head.output", "kernel")
+
+    {:ok,
+     %State{
+       embed_tokens: embed_tokens,
+       layers: layers,
+       norm: norm,
+       lm_head: lm_head,
+       rope_freqs: Rope.freqs_from_config!(config),
+       config: config
+     }}
+  rescue
+    exception -> {:error, Exception.message(exception)}
+  end
+
+  def from_model_info(%{params: %{data: _params}, spec: %Bumblebee.Text.Llama{}}, opts) do
+    {:error, "expected opts to be a keyword list, got: #{inspect(opts)}"}
+  end
+
+  def from_model_info(%{spec: spec}, _opts) do
+    {:error, "expected Bumblebee.Text.Llama spec, got: #{inspect(spec)}"}
+  end
+
+  def from_model_info(_model_info, _opts),
+    do: {:error, "expected Bumblebee model_info with params and spec"}
+
+  @doc """
+  Loads a native dense Llama state directly from a local safetensors directory.
+
+  This fast path is intended for standard dense Llama checkpoints using
+  Hugging Face tensor names, such as local f16/bf16 conversions. Projection
+  weights are transposed once at load time from safetensors `{out, in}` layout
+  into the native dense `{in, out}` layout.
+  """
+  @spec from_safetensors_dir(Path.t(), keyword()) :: {:ok, State.t()} | {:error, term()}
+  def from_safetensors_dir(path, opts \\ []) do
+    path = Path.expand(path)
+
+    with {:ok, shards} <- safetensors_paths(path) do
+      from_safetensors_files(Path.join(path, "config.json"), shards, opts)
+    end
+  rescue
+    exception -> {:error, Exception.message(exception)}
+  end
+
+  @doc """
+  Loads a native dense Llama state from explicit config and safetensors files.
+
+  This is useful when a repository cache stores files by content addressed names
+  rather than as a model directory.
+  """
+  @spec from_safetensors_files(Path.t(), [Path.t()], keyword()) ::
+          {:ok, State.t()} | {:error, term()}
+  def from_safetensors_files(config_path, safetensors_paths, opts \\ []) do
+    device = Keyword.get(opts, :device, :gpu)
+    type = Keyword.get(opts, :type)
+
+    with :ok <- validate_type(type),
+         :ok <- validate_device(device),
+         {:ok, config} <- read_config_file(config_path),
+         {:ok, tensors} <- read_safetensors_files(safetensors_paths) do
+      backend = {EMLX.Backend, device: device}
+
+      state =
+        Nx.with_default_backend(backend, fn ->
+          build_safetensors_state(tensors, config, type)
+        end)
+
+      {:ok, state}
+    end
+  rescue
+    exception -> {:error, Exception.message(exception)}
+  end
+
+  defp config_from_spec(spec, opts) do
+    validate_supported_spec!(spec)
+
+    %{
+      hidden_size: spec.hidden_size,
+      intermediate_size: spec.intermediate_size,
+      num_attention_heads: spec.num_attention_heads,
+      num_key_value_heads: spec.num_key_value_heads || spec.num_attention_heads,
+      head_dim: spec.attention_head_size || div(spec.hidden_size, spec.num_attention_heads),
+      num_hidden_layers: spec.num_blocks,
+      vocab_size: spec.vocab_size,
+      rms_norm_eps: spec.layer_norm_epsilon,
+      rope_theta: spec.rotary_embedding_base,
+      rope_scaling: normalize_rope_scaling(spec.rotary_embedding_scaling_strategy),
+      tie_word_embeddings: spec.tie_word_embeddings,
+      eos_token_id: token_id_from_opts(opts, :eos_token_id),
+      bos_token_id: token_id_from_opts(opts, :bos_token_id),
+      dense_layers?: true
+    }
+  end
+
+  defp token_id_from_opts(opts, key) do
+    token_id =
+      case Keyword.fetch(opts, key) do
+        {:ok, value} -> value
+        :error -> generation_config_token_id(opts[:generation_config], key)
+      end
+
+    validate_token_id!(token_id, key)
+  end
+
+  defp generation_config_token_id(%Bumblebee.Text.GenerationConfig{} = config, key),
+    do: Map.get(config, key)
+
+  defp generation_config_token_id(nil, _key), do: nil
+
+  defp generation_config_token_id(other, _key) do
+    raise ArgumentError,
+          "expected :generation_config to be a Bumblebee.Text.GenerationConfig struct, got: #{inspect(other)}"
+  end
+
+  defp validate_token_id!(nil, _key), do: nil
+
+  defp validate_token_id!(token_id, _key) when is_integer(token_id) and token_id >= 0,
+    do: token_id
+
+  defp validate_token_id!(token_ids, key)
+       when is_list(token_ids) and token_ids != [] do
+    if Enum.all?(token_ids, &(is_integer(&1) and &1 >= 0)) do
+      token_ids
+    else
+      raise ArgumentError,
+            "expected #{inspect(key)} to be a non-negative integer or a list of non-negative integers, got: #{inspect(token_ids)}"
+    end
+  end
+
+  defp validate_token_id!(token_id, key) do
+    raise ArgumentError,
+          "expected #{inspect(key)} to be a non-negative integer or a list of non-negative integers, got: #{inspect(token_id)}"
+  end
+
+  defp read_config_file(config_path) do
+    with {:ok, json} <- File.read(config_path),
+         {:ok, raw} <- Jason.decode(json),
+         :ok <- validate_supported_config(raw) do
+      {:ok,
+       %{
+         hidden_size: raw["hidden_size"],
+         intermediate_size: raw["intermediate_size"],
+         num_attention_heads: raw["num_attention_heads"],
+         num_key_value_heads: raw["num_key_value_heads"] || raw["num_attention_heads"],
+         head_dim: raw["head_dim"] || div(raw["hidden_size"], raw["num_attention_heads"]),
+         num_hidden_layers: raw["num_hidden_layers"],
+         vocab_size: raw["vocab_size"],
+         rms_norm_eps: raw["rms_norm_eps"] || 1.0e-6,
+         rope_theta: raw["rope_theta"] || 10_000.0,
+         rope_scaling: normalize_rope_scaling(raw["rope_scaling"]),
+         max_position_embeddings: raw["max_position_embeddings"],
+         tie_word_embeddings: raw["tie_word_embeddings"] || false,
+         eos_token_id: raw["eos_token_id"],
+         bos_token_id: raw["bos_token_id"],
+         dense_layers?: true
+       }}
+    end
+  end
+
+  defp validate_supported_spec!(%{activation: activation}) when activation in [nil, :silu],
+    do: :ok
+
+  defp validate_supported_spec!(%{activation: activation}) do
+    raise ArgumentError,
+          "native dense Llama generation supports activation :silu only, got: #{inspect(activation)}"
+  end
+
+  defp validate_supported_config(raw) do
+    with :ok <- validate_false_config(raw, "attention_bias"),
+         :ok <- validate_false_config(raw, "mlp_bias"),
+         :ok <- validate_hidden_act(raw) do
+      :ok
+    end
+  end
+
+  defp validate_false_config(raw, key) do
+    case Map.get(raw, key, false) do
+      false ->
+        :ok
+
+      nil ->
+        :ok
+
+      true ->
+        {:error, "native dense Llama generation does not support #{key}=true"}
+
+      other ->
+        {:error,
+         "native dense Llama generation expected #{key} to be false or absent, got: #{inspect(other)}"}
+    end
+  end
+
+  defp validate_hidden_act(raw) do
+    case raw["hidden_act"] || raw["hidden_activation"] do
+      nil ->
+        :ok
+
+      "silu" ->
+        :ok
+
+      other ->
+        {:error,
+         "native dense Llama generation supports hidden_act \"silu\" only, got: #{inspect(other)}"}
+    end
+  end
+
+  defp safetensors_paths(path) do
+    shards =
+      path
+      |> File.ls!()
+      |> Enum.filter(&String.ends_with?(&1, ".safetensors"))
+      |> Enum.sort()
+      |> Enum.map(&Path.join(path, &1))
+
+    if shards == [] do
+      {:error, "No .safetensors files found in #{path}"}
+    else
+      {:ok, shards}
+    end
+  end
+
+  defp read_safetensors_files([]), do: {:error, "No .safetensors files given"}
+
+  defp read_safetensors_files([path]), do: {:ok, Safetensors.read!(path, lazy: true)}
+
+  defp read_safetensors_files(paths) do
+    tensors =
+      Enum.reduce(paths, %{}, fn path, acc ->
+        Map.merge(acc, Safetensors.read!(path, lazy: true))
+      end)
+
+    {:ok, tensors}
+  end
+
+  defp build_safetensors_state(tensors, config, type) do
+    tensor = fn key -> safetensors_tensor!(tensors, key, type) end
+    linear = fn key -> tensor.(key) |> Nx.transpose() end
+
+    layers =
+      for i <- 0..(config.num_hidden_layers - 1) do
+        prefix = "model.layers.#{i}"
+
+        Model.layer(
+          tensor.("#{prefix}.input_layernorm.weight"),
+          tensor.("#{prefix}.post_attention_layernorm.weight"),
+          linear.("#{prefix}.self_attn.q_proj.weight"),
+          linear.("#{prefix}.self_attn.k_proj.weight"),
+          linear.("#{prefix}.self_attn.v_proj.weight"),
+          linear.("#{prefix}.self_attn.o_proj.weight"),
+          linear.("#{prefix}.mlp.gate_proj.weight"),
+          linear.("#{prefix}.mlp.up_proj.weight"),
+          linear.("#{prefix}.mlp.down_proj.weight")
+        )
+      end
+
+    embed_tokens = tensor.("model.embed_tokens.weight")
+
+    lm_head =
+      cond do
+        config.tie_word_embeddings ->
+          embed_tokens
+
+        Map.has_key?(tensors, "lm_head.weight") ->
+          tensor.("lm_head.weight")
+
+        true ->
+          tensor.("lm_head.weight")
+      end
+
+    %State{
+      embed_tokens: embed_tokens,
+      layers: layers,
+      norm: tensor.("model.norm.weight"),
+      lm_head: lm_head,
+      rope_freqs: Rope.freqs_from_config!(config),
+      config: config
+    }
+  end
+
+  defp validate_type(type) when type in [nil, :f16, :bf16], do: :ok
+
+  defp validate_type(type) do
+    {:error, "expected :type to be nil, :f16, or :bf16, got: #{inspect(type)}"}
+  end
+
+  defp validate_device(:gpu), do: :ok
+
+  defp validate_device(device) do
+    {:error,
+     "native dense Llama generation currently supports device: :gpu only, got: #{inspect(device)}"}
+  end
+
+  defp normalize_rope_scaling(nil), do: nil
+
+  defp normalize_rope_scaling(%{type: :llama3} = scaling), do: scaling
+
+  defp normalize_rope_scaling(%{"rope_type" => "llama3"} = scaling) do
+    %{
+      type: :llama3,
+      factor: scaling["factor"],
+      low_frequency_factor: scaling["low_freq_factor"],
+      high_frequency_factor: scaling["high_freq_factor"],
+      original_max_positions: scaling["original_max_position_embeddings"]
+    }
+  end
+
+  defp normalize_rope_scaling(%{"type" => "llama3"} = scaling) do
+    normalize_rope_scaling(Map.put(scaling, "rope_type", "llama3"))
+  end
+
+  defp normalize_rope_scaling(%{"rope_type" => type} = scaling) do
+    raise ArgumentError,
+          "native dense Llama generation supports nil or llama3 rope scaling, got: #{inspect(%{scaling | "rope_type" => type})}"
+  end
+
+  defp normalize_rope_scaling(%{type: type} = scaling) do
+    raise ArgumentError,
+          "native dense Llama generation supports nil or :llama3 rope scaling, got: #{inspect(%{scaling | type: type})}"
+  end
+
+  defp normalize_rope_scaling(scaling) do
+    raise ArgumentError,
+          "native dense Llama generation supports nil or :llama3 rope scaling, got: #{inspect(scaling)}"
+  end
+
+  defp safetensors_tensor!(tensors, key, type) do
+    tensors
+    |> Map.fetch!(key)
+    |> Nx.to_tensor()
+    |> maybe_cast(type)
+  end
+
+  defp maybe_cast(tensor, nil), do: tensor
+  defp maybe_cast(tensor, :f16), do: Nx.as_type(tensor, :f16)
+  defp maybe_cast(tensor, :bf16), do: Nx.as_type(tensor, :bf16)
+
+  defp tensor!(params, scope, name) do
+    case params do
+      %{^scope => %{^name => tensor}} ->
+        Nx.backend_transfer(tensor, @gpu)
+
+      _missing ->
+        raise ArgumentError, "missing Bumblebee parameter #{scope}.#{name}"
+    end
+  end
+end

--- a/emlx_axon/lib/emlx_axon/llama/generate.ex
+++ b/emlx_axon/lib/emlx_axon/llama/generate.ex
@@ -1,0 +1,779 @@
+defmodule EMLXAxon.Llama.Generate do
+  @moduledoc """
+  Autoregressive token generation loop.
+
+  Generation supports immediate host sync after each token, deferred host sync
+  at the end of generation, and chunked host sync for lower overhead while still
+  allowing EOS checks between chunks. Greedy dense states use the native Llama
+  fast path when available, while sampler paths fall back to tensor based
+  forward calls.
+
+  ## Usage
+
+      {:ok, state}     = EMLXAxon.Llama.DenseLoader.from_safetensors_dir(model_path, type: :f16)
+      {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "meta-llama/Llama-3.2-1B"})
+
+      encoded   = Bumblebee.apply_tokenizer(tokenizer, "Hello")
+      input_ids = encoded["input_ids"]
+
+      {tokens, timing} = Generate.generate(input_ids, state,
+        max_new_tokens: 100,
+        sampler: :greedy
+      )
+  """
+
+  alias EMLXAxon.Llama.{Model, Sampler}
+
+  @cpu_backend Nx.BinaryBackend
+
+  @default_max_new_tokens 100
+  @default_max_len 2048
+
+  @doc """
+  Run the autoregressive generation loop.
+
+  ## Options
+
+  - `:max_new_tokens` — max number of tokens to generate (default 100)
+  - `:max_len`        — KV cache allocation size (default 2048); ignored when `:kv_cache` is given
+  - `:kv_cache`       — pre-allocated KV cache from `Model.init_kv_cache/2`; if provided,
+                        `Model.init_kv_cache/2` is skipped. The cache is used as-is — callers
+                        are responsible for ensuring it is clean (stale K/V beyond `current_len`
+                        is never read because `Model.forward/4` slices to the valid prefix).
+  - `:sampler`        — `:greedy | :top_p_cpu | :top_p_gpu` (default `:greedy`)
+  - `:temperature`    — float, passed to samplers that use it (default 0.95)
+  - `:top_p`          — nucleus cutoff for `:top_p_cpu` (default 0.9);
+                        `:top_p_gpu` currently uses temperature sampling only
+  - `:rng_key`        — `Nx.Random.key/1`, used by `:top_p_gpu` (split each step via
+                        `Nx.Random.split/2`; avoids host time + transfer per token)
+  - `:profile_timing` — when `true`, record `per_token_ms` decode samples using
+                        microsecond monotonic time; defaults to `false`
+                        to keep the generation hot path free of timing for each token
+                        overhead
+                        (prefill/total wall time is still measured)
+  - `:token_callback` — optional function of arity 1 called with each generated token id
+                        after the token has been evaluated and copied to the host
+  - `:chunk_callback` — optional function of arity 1 called with a list of generated
+                        token ids whenever a deferred host sync chunk is copied to
+                        the host. This is only used with `host_sync: {:chunk, n}`.
+  - `:chunk_callback_first_token` — when `true`, emit the prefill token through
+                        `:chunk_callback` immediately and then chunk the remaining
+                        decode tokens. Defaults to `false` to preserve generic
+                        chunk callback semantics.
+  - `:return_kv_cache` — when `true`, include the final KV cache in the returned
+                         metadata so serving layers can reuse the owned cache on
+                         the next request
+  - `:host_sync`      — `:per_token | :end | {:chunk, pos_integer()}` (default
+                        `:per_token`). `:end` keeps greedy/GPU sampled tokens
+                        on the EMLX backend until generation finishes, then copies
+                        token ids to the host once as a stacked tensor. `{:chunk, n}`
+                        copies stacked token chunks every `n` generated tokens so it
+                        can stop soon after EOS. Deferred host sync modes cannot be
+                        used with `:token_callback`.
+
+  ## Returns
+
+  `{generated_token_ids, %{timing: timing_map}}` where `timing_map` has:
+  - `:prefill_ms`     — first-token time in milliseconds, with microsecond resolution
+  - `:per_token_ms`   — list of per-token decode times, with microsecond resolution
+                        (median ≈ steady-state)
+  - `:total_ms`       — wall time for the whole call, with microsecond resolution
+  """
+  @spec generate(Nx.Tensor.t(), Model.State.t(), keyword()) ::
+          {[non_neg_integer()], map()}
+  def generate(input_ids, %Model.State{} = state, opts \\ []) do
+    ensure_single_batch!(input_ids)
+
+    requested_max_new =
+      opts
+      |> Keyword.get(:max_new_tokens, @default_max_new_tokens)
+      |> validate_max_new_tokens!()
+
+    configured_max_len = opts |> Keyword.get(:max_len, @default_max_len) |> validate_max_len!()
+    sampler = opts |> Keyword.get(:sampler, :greedy) |> validate_sampler!()
+    temp = Keyword.get(opts, :temperature, 0.95)
+    top_p = Keyword.get(opts, :top_p, 0.9)
+    validate_sampler_options!(sampler, temp, top_p)
+    input_length = elem(Nx.shape(input_ids), 1)
+
+    kv_cache =
+      case Keyword.fetch(opts, :kv_cache) do
+        {:ok, prealloc} -> prealloc
+        :error -> Model.init_kv_cache(state, configured_max_len)
+      end
+
+    max_len = effective_max_len(configured_max_len, kv_cache)
+    max_new = safe_max_new_tokens!(requested_max_new, max_len, input_length)
+
+    rng_key =
+      if sampler == :top_p_gpu do
+        Keyword.get(opts, :rng_key, Nx.Random.key(42))
+      else
+        nil
+      end
+
+    profile_timing? = Keyword.get(opts, :profile_timing, false)
+    token_callback = Keyword.get(opts, :token_callback)
+    chunk_callback = Keyword.get(opts, :chunk_callback)
+    chunk_callback_first_token? = Keyword.get(opts, :chunk_callback_first_token, false)
+    return_kv_cache? = Keyword.get(opts, :return_kv_cache, false)
+
+    host_sync =
+      host_sync_mode(Keyword.get(opts, :host_sync, :per_token), sampler, token_callback)
+
+    # Prefill: pass the full prompt in one forward
+    t0 = timing_now_us()
+
+    {rng_key, first_gpu_key} = advance_rng_for_gpu(sampler, rng_key)
+
+    {first_token, kv_cache} =
+      forward_sample(input_ids, kv_cache, 0, sampler, temp, top_p, first_gpu_key, state)
+
+    t1 = timing_now_us()
+    prefill_ms = elapsed_ms(t0, t1)
+
+    # Native path uses `{1, prompt_len}`; KV length tracks sequence dimension.
+    current_len = input_length
+    eos_id = eos_token_id(state)
+
+    decode_ctx =
+      {eos_id, sampler, temp, top_p, state, profile_timing?, token_callback, chunk_callback}
+
+    # Tail-recursive decode: max_new - 1 steps after prefill (no Enum range / closure).
+    remaining_decode = max(max_new - 1, 0)
+
+    {tokens, per_token_ms, kv_cache, _cur, _rng} =
+      case host_sync do
+        :per_token ->
+          first_token_id = Nx.to_number(first_token)
+          emit_token(token_callback, first_token_id)
+
+          decode_tokens(
+            remaining_decode,
+            [first_token_id],
+            [],
+            kv_cache,
+            current_len,
+            rng_key,
+            decode_ctx
+          )
+
+        :end ->
+          decode_tensors(
+            remaining_decode,
+            [first_token],
+            [],
+            kv_cache,
+            current_len,
+            rng_key,
+            decode_ctx
+          )
+
+        {:chunk, chunk_size} ->
+          decode_tensor_chunks_start(
+            remaining_decode,
+            first_token,
+            kv_cache,
+            current_len,
+            rng_key,
+            decode_ctx,
+            chunk_size,
+            chunk_callback_first_token?
+          )
+      end
+
+    t_end = timing_now_us()
+
+    timing = %{
+      prefill_ms: prefill_ms,
+      per_token_ms: :lists.reverse(per_token_ms),
+      total_ms: elapsed_ms(t0, t_end)
+    }
+
+    metadata =
+      %{timing: timing}
+      |> Map.put(:finish_reason, finish_reason(tokens, eos_id, requested_max_new, max_new))
+      |> maybe_put_kv_cache(return_kv_cache?, kv_cache)
+
+    {:lists.reverse(tokens), metadata}
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────────────
+
+  defp validate_max_new_tokens!(max_new) when is_integer(max_new) and max_new > 0,
+    do: max_new
+
+  defp validate_max_new_tokens!(max_new) do
+    raise ArgumentError,
+          "expected :max_new_tokens to be a positive integer, got: #{inspect(max_new)}"
+  end
+
+  defp validate_max_len!(max_len) when is_integer(max_len) and max_len > 0,
+    do: max_len
+
+  defp validate_max_len!(max_len) do
+    raise ArgumentError,
+          "expected :max_len to be a positive integer, got: #{inspect(max_len)}"
+  end
+
+  defp validate_sampler!(sampler) when sampler in [:greedy, :top_p_cpu, :top_p_gpu], do: sampler
+
+  defp validate_sampler!(sampler) do
+    raise ArgumentError,
+          "expected :sampler to be :greedy, :top_p_cpu, or :top_p_gpu, got: #{inspect(sampler)}"
+  end
+
+  defp validate_sampler_options!(:greedy, _temperature, _top_p), do: :ok
+
+  defp validate_sampler_options!(:top_p_gpu, temperature, _top_p) do
+    validate_temperature!(temperature)
+  end
+
+  defp validate_sampler_options!(:top_p_cpu, temperature, top_p) do
+    validate_temperature!(temperature)
+    validate_top_p!(top_p)
+  end
+
+  defp validate_temperature!(temperature) when is_number(temperature) and temperature > 0,
+    do: :ok
+
+  defp validate_temperature!(temperature) do
+    raise ArgumentError,
+          "expected :temperature to be a positive number, got: #{inspect(temperature)}"
+  end
+
+  defp validate_top_p!(top_p) when is_number(top_p) and top_p > 0 and top_p <= 1,
+    do: :ok
+
+  defp validate_top_p!(top_p) do
+    raise ArgumentError,
+          "expected :top_p to be a number greater than 0.0 and less than or equal to 1.0, got: #{inspect(top_p)}"
+  end
+
+  defp timing_now_us, do: System.monotonic_time(:microsecond)
+  defp elapsed_ms(start_us, end_us), do: (end_us - start_us) / 1000
+
+  defp safe_max_new_tokens!(requested_max_new, max_len, input_length) do
+    safe_max_new = max_len - input_length + 1
+
+    cond do
+      input_length > max_len ->
+        raise ArgumentError,
+              "expected :max_len to be greater than or equal to input length, " <>
+                "got max_len=#{inspect(max_len)} and input_length=#{inspect(input_length)}"
+
+      safe_max_new < requested_max_new ->
+        safe_max_new
+
+      true ->
+        requested_max_new
+    end
+  end
+
+  defp finish_reason(tokens, eos_id, _requested_max_new, _max_new) do
+    if Enum.any?(tokens, &eos_token?(&1, eos_id)), do: :stop, else: :length
+  end
+
+  defp maybe_put_kv_cache(metadata, true, kv_cache), do: Map.put(metadata, :kv_cache, kv_cache)
+  defp maybe_put_kv_cache(metadata, false, _kv_cache), do: metadata
+
+  defp effective_max_len(configured_max_len, kv_cache) do
+    case kv_cache_capacity(kv_cache) do
+      nil -> configured_max_len
+      capacity -> min(configured_max_len, capacity)
+    end
+  end
+
+  defp kv_cache_capacity([{k_cache, _v_cache} | _rest]) do
+    case cache_shape(k_cache) do
+      {_batch, _heads, max_len, _head_dim} -> max_len
+      _other -> nil
+    end
+  end
+
+  defp kv_cache_capacity(_kv_cache), do: nil
+
+  defp cache_shape(%Nx.Tensor{} = tensor), do: Nx.shape(tensor)
+
+  defp cache_shape({device, ref}) when is_atom(device) and is_reference(ref),
+    do: EMLX.shape({device, ref})
+
+  defp cache_shape(_cache), do: nil
+
+  defp host_sync_mode(:per_token, _sampler, _token_callback), do: :per_token
+
+  defp host_sync_mode(:end, sampler, nil) when sampler in [:greedy, :top_p_gpu], do: :end
+
+  defp host_sync_mode({:chunk, chunk_size}, sampler, nil)
+       when sampler in [:greedy, :top_p_gpu] and is_integer(chunk_size) and chunk_size > 0,
+       do: {:chunk, chunk_size}
+
+  defp host_sync_mode({:chunk, chunk_size}, _sampler, _token_callback)
+       when not is_integer(chunk_size) or chunk_size <= 0 do
+    raise ArgumentError,
+          "expected :host_sync chunk size to be a positive integer, got: #{inspect(chunk_size)}"
+  end
+
+  defp host_sync_mode(:end, _sampler, token_callback) when is_function(token_callback, 1),
+    do: :per_token
+
+  defp host_sync_mode({:chunk, _chunk_size}, _sampler, token_callback)
+       when is_function(token_callback, 1),
+       do: :per_token
+
+  defp host_sync_mode(:end, _sampler, _token_callback), do: :per_token
+  defp host_sync_mode({:chunk, _chunk_size}, _sampler, _token_callback), do: :per_token
+
+  defp host_sync_mode(other, _sampler, _token_callback) do
+    raise ArgumentError,
+          "expected :host_sync to be :per_token, :end, or {:chunk, positive_integer}, got: #{inspect(other)}"
+  end
+
+  defp decode_tokens(0, acc_tokens, acc_times, kv, cur, rng_key, _ctx) do
+    {acc_tokens, acc_times, kv, cur, rng_key}
+  end
+
+  defp decode_tokens(n, acc_tokens, acc_times, kv, cur, rng_key, ctx)
+       when is_integer(n) and n > 0 do
+    {eos_id, _, _, _, _, _, _, _} = ctx
+    [last_id | _] = acc_tokens
+
+    if eos_token?(last_id, eos_id) do
+      {acc_tokens, acc_times, kv, cur, rng_key}
+    else
+      decode_step_timed(n, acc_tokens, acc_times, kv, cur, rng_key, ctx, last_id)
+    end
+  end
+
+  defp decode_step_timed(n, acc_tokens, acc_times, kv, cur, rng_key, ctx, last_id) do
+    {_eos_id, sampler, temp, top_p, state, profile_timing?, token_callback, _chunk_callback} =
+      ctx
+
+    ts = if profile_timing?, do: timing_now_us()
+
+    {rng_key, gpu_key} = advance_rng_for_gpu(sampler, rng_key)
+
+    {next_token_id, kv_new} =
+      forward_sample_token_id(last_id, kv, cur, sampler, temp, top_p, gpu_key, state)
+
+    emit_token(token_callback, next_token_id)
+
+    acc_times =
+      if profile_timing? do
+        te = timing_now_us()
+        [elapsed_ms(ts, te) | acc_times]
+      else
+        acc_times
+      end
+
+    decode_tokens(
+      n - 1,
+      [next_token_id | acc_tokens],
+      acc_times,
+      kv_new,
+      cur + 1,
+      rng_key,
+      ctx
+    )
+  end
+
+  defp decode_tensors(0, acc_tokens, acc_times, kv, cur, rng_key, ctx) do
+    {eos_id, _sampler, _temp, _top_p, _state, _profile_timing?, _token_callback, _chunk_callback} =
+      ctx
+
+    tokens =
+      acc_tokens
+      |> Enum.reverse()
+      |> tokens_to_host()
+      |> truncate_at_eos(eos_id)
+
+    {Enum.reverse(tokens), acc_times, kv, cur, rng_key}
+  end
+
+  defp decode_tensors(n, acc_tokens, acc_times, kv, cur, rng_key, ctx)
+       when is_integer(n) and n > 0 do
+    {_eos_id, sampler, temp, top_p, state, profile_timing?, _token_callback, _chunk_callback} =
+      ctx
+
+    [last_token | _] = acc_tokens
+
+    ts = if profile_timing?, do: timing_now_us()
+    decode_input = Nx.reshape(last_token, {1, 1})
+
+    {rng_key, gpu_key} = advance_rng_for_gpu(sampler, rng_key)
+
+    {next_token, kv_new} =
+      forward_sample(decode_input, kv, cur, sampler, temp, top_p, gpu_key, state)
+
+    acc_times =
+      if profile_timing? do
+        te = timing_now_us()
+        [elapsed_ms(ts, te) | acc_times]
+      else
+        acc_times
+      end
+
+    decode_tensors(
+      n - 1,
+      [next_token | acc_tokens],
+      acc_times,
+      kv_new,
+      cur + 1,
+      rng_key,
+      ctx
+    )
+  end
+
+  defp decode_tensor_chunks_start(
+         remaining_decode,
+         first_token,
+         kv_cache,
+         current_len,
+         rng_key,
+         ctx,
+         chunk_size,
+         false
+       ) do
+    decode_tensor_chunks(
+      remaining_decode,
+      first_token,
+      [first_token],
+      1,
+      [],
+      [],
+      kv_cache,
+      current_len,
+      rng_key,
+      ctx,
+      chunk_size
+    )
+  end
+
+  defp decode_tensor_chunks_start(
+         remaining_decode,
+         first_token,
+         kv_cache,
+         current_len,
+         rng_key,
+         {eos_id, _sampler, _temp, _top_p, _state, _profile_timing?, _token_callback,
+          chunk_callback} = ctx,
+         chunk_size,
+         true
+       )
+       when is_function(chunk_callback, 1) do
+    first_token_id = Nx.to_number(first_token)
+    emit_chunk(chunk_callback, [first_token_id])
+
+    if eos_token?(first_token_id, eos_id) do
+      {[first_token_id], [], kv_cache, current_len, rng_key}
+    else
+      decode_tensor_chunks(
+        remaining_decode,
+        first_token,
+        [],
+        0,
+        [first_token_id],
+        [],
+        kv_cache,
+        current_len,
+        rng_key,
+        ctx,
+        chunk_size
+      )
+    end
+  end
+
+  defp decode_tensor_chunks(
+         0,
+         _last_token,
+         pending_tokens,
+         _pending_count,
+         host_tokens,
+         acc_times,
+         kv,
+         cur,
+         rng_key,
+         ctx,
+         _chunk_size
+       ) do
+    {eos_id, _sampler, _temp, _top_p, _state, _profile_timing?, _token_callback, chunk_callback} =
+      ctx
+
+    tokens = flush_chunk(host_tokens, pending_tokens, eos_id, chunk_callback)
+    {:lists.reverse(tokens), acc_times, kv, cur, rng_key}
+  end
+
+  defp decode_tensor_chunks(
+         n,
+         last_token,
+         pending_tokens,
+         pending_count,
+         host_tokens,
+         acc_times,
+         kv,
+         cur,
+         rng_key,
+         ctx,
+         chunk_size
+       )
+       when is_integer(n) and n > 0 do
+    {eos_id, sampler, _temp, _top_p, state, profile_timing?, _token_callback, chunk_callback} =
+      ctx
+
+    case maybe_flush_chunk(
+           host_tokens,
+           pending_tokens,
+           pending_count,
+           eos_id,
+           chunk_size,
+           chunk_callback
+         ) do
+      {:halt, tokens} ->
+        {Enum.reverse(tokens), acc_times, kv, cur, rng_key}
+
+      {:cont, host_tokens, pending_tokens, pending_count} ->
+        ts = if profile_timing?, do: timing_now_us()
+        decode_input = Nx.reshape(last_token, {1, 1})
+
+        if sampler == :greedy and not profile_timing? do
+          chunk_count = min(n, chunk_size - pending_count)
+
+          case Model.forward_greedy_chunk(decode_input, kv, cur, chunk_count, state) do
+            {next_tokens, kv_new} ->
+              {last_token, pending_tokens} =
+                append_reversed_with_last(next_tokens, pending_tokens)
+
+              decode_tensor_chunks(
+                n - chunk_count,
+                last_token,
+                pending_tokens,
+                pending_count + chunk_count,
+                host_tokens,
+                acc_times,
+                kv_new,
+                cur + chunk_count,
+                rng_key,
+                ctx,
+                chunk_size
+              )
+
+            :fallback ->
+              decode_tensor_chunk_step(
+                n,
+                decode_input,
+                pending_tokens,
+                pending_count,
+                host_tokens,
+                acc_times,
+                kv,
+                cur,
+                rng_key,
+                ctx,
+                ts,
+                chunk_size
+              )
+          end
+        else
+          decode_tensor_chunk_step(
+            n,
+            decode_input,
+            pending_tokens,
+            pending_count,
+            host_tokens,
+            acc_times,
+            kv,
+            cur,
+            rng_key,
+            ctx,
+            ts,
+            chunk_size
+          )
+        end
+    end
+  end
+
+  defp append_reversed_with_last([token | rest], pending_tokens) do
+    append_reversed_with_last(rest, token, [token | pending_tokens])
+  end
+
+  defp append_reversed_with_last([], _pending_tokens) do
+    raise ArgumentError, "expected at least one generated token in a greedy chunk"
+  end
+
+  defp append_reversed_with_last([token | rest], _last_token, pending_tokens) do
+    append_reversed_with_last(rest, token, [token | pending_tokens])
+  end
+
+  defp append_reversed_with_last([], last_token, pending_tokens), do: {last_token, pending_tokens}
+
+  defp decode_tensor_chunk_step(
+         n,
+         decode_input,
+         pending_tokens,
+         pending_count,
+         host_tokens,
+         acc_times,
+         kv,
+         cur,
+         rng_key,
+         ctx,
+         ts,
+         chunk_size
+       ) do
+    {_eos_id, sampler, temp, top_p, state, profile_timing?, _token_callback, _chunk_callback} =
+      ctx
+
+    {rng_key, gpu_key} = advance_rng_for_gpu(sampler, rng_key)
+
+    {next_token, kv_new} =
+      forward_sample(decode_input, kv, cur, sampler, temp, top_p, gpu_key, state)
+
+    acc_times =
+      if profile_timing? do
+        te = timing_now_us()
+        [elapsed_ms(ts, te) | acc_times]
+      else
+        acc_times
+      end
+
+    decode_tensor_chunks(
+      n - 1,
+      next_token,
+      [next_token | pending_tokens],
+      pending_count + 1,
+      host_tokens,
+      acc_times,
+      kv_new,
+      cur + 1,
+      rng_key,
+      ctx,
+      chunk_size
+    )
+  end
+
+  defp forward_sample(input_ids, kv, cur, :greedy, _temp, _top_p, _key, state) do
+    Model.forward_greedy(input_ids, kv, cur, state)
+  end
+
+  defp forward_sample(input_ids, kv, cur, sampler, temp, top_p, key, state) do
+    {logits, kv_new} = Model.forward(input_ids, kv, cur, state)
+    {sample(logits, sampler, temp, top_p, key), kv_new}
+  end
+
+  defp forward_sample_token_id(token_id, kv, cur, :greedy, _temp, _top_p, _key, state)
+       when is_integer(token_id) do
+    Model.forward_greedy_decode_token_id(token_id, kv, cur, state)
+  end
+
+  defp forward_sample_token_id(token_id, kv, cur, sampler, temp, top_p, key, state)
+       when is_integer(token_id) do
+    input_ids = Nx.tensor([[token_id]], type: :s64, backend: @cpu_backend)
+    {next_token, kv_new} = forward_sample(input_ids, kv, cur, sampler, temp, top_p, key, state)
+    {Nx.to_number(next_token), kv_new}
+  end
+
+  defp sample(logits, :top_p_cpu, temp, top_p, _key),
+    do: Sampler.top_p_cpu(logits, temp, top_p)
+
+  defp sample(logits, :top_p_gpu, temp, _top_p, gpu_key) do
+    Sampler.top_p_gpu(logits, gpu_key, temperature: temp)
+  end
+
+  defp emit_token(nil, _token_id), do: :ok
+
+  defp emit_token(callback, token_id) when is_function(callback, 1) do
+    callback.(token_id)
+    :ok
+  end
+
+  defp ensure_single_batch!(input_ids) do
+    case Nx.shape(input_ids) do
+      {1, _seq_len} ->
+        :ok
+
+      {batch_size, _seq_len} ->
+        raise ArgumentError,
+              "native Llama generation currently supports batch size 1, got batch size #{batch_size}"
+
+      shape ->
+        raise ArgumentError,
+              "expected input_ids to have shape {1, sequence_length}, got: #{inspect(shape)}"
+    end
+  end
+
+  defp emit_chunk(nil, _token_ids), do: :ok
+  defp emit_chunk(_callback, []), do: :ok
+
+  defp emit_chunk(callback, token_ids) when is_function(callback, 1) do
+    callback.(token_ids)
+    :ok
+  end
+
+  defp truncate_at_eos(tokens, eos_id) do
+    case Enum.split_while(tokens, &(not eos_token?(&1, eos_id))) do
+      {prefix, []} -> prefix
+      {prefix, [eos_token | _rest]} -> prefix ++ [eos_token]
+    end
+  end
+
+  defp maybe_flush_chunk(host_tokens, pending_tokens, pending_count, eos_id, chunk_size, callback)
+       when pending_count >= chunk_size do
+    tokens = flush_chunk(host_tokens, pending_tokens, eos_id, callback)
+
+    if eos_seen?(tokens, eos_id) do
+      {:halt, tokens}
+    else
+      {:cont, tokens, [], 0}
+    end
+  end
+
+  defp maybe_flush_chunk(
+         host_tokens,
+         pending_tokens,
+         pending_count,
+         _eos_id,
+         _chunk_size,
+         _callback
+       ),
+       do: {:cont, host_tokens, pending_tokens, pending_count}
+
+  defp flush_chunk(host_tokens, [] = _pending_tokens, _eos_id, _callback), do: host_tokens
+
+  defp flush_chunk(host_tokens, pending_tokens, eos_id, callback) do
+    emitted =
+      pending_tokens
+      |> :lists.reverse()
+      |> tokens_to_host()
+      |> truncate_at_eos(eos_id)
+
+    emit_chunk(callback, emitted)
+    host_tokens ++ emitted
+  end
+
+  defp eos_seen?(tokens, eos_id), do: Enum.any?(tokens, &eos_token?(&1, eos_id))
+
+  defp eos_token?(token_id, eos_ids) when is_list(eos_ids), do: token_id in eos_ids
+  defp eos_token?(token_id, eos_id), do: token_id == eos_id
+
+  defp tokens_to_host(tokens) do
+    Enum.flat_map(tokens, &Nx.to_flat_list/1)
+  end
+
+  defp advance_rng_for_gpu(:top_p_gpu, key) do
+    keys = Nx.Random.split(key, parts: 2)
+
+    k_this =
+      keys[[0..0, ..]]
+      |> Nx.squeeze(axes: [0])
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    k_next = keys[[1..1, ..]] |> Nx.squeeze(axes: [0])
+    {k_next, k_this}
+  end
+
+  defp advance_rng_for_gpu(_sampler, key), do: {key, nil}
+
+  defp eos_token_id(%Model.State{config: cfg}) do
+    cfg[:eos_token_id] || 2
+  end
+end

--- a/emlx_axon/lib/emlx_axon/llama/model.ex
+++ b/emlx_axon/lib/emlx_axon/llama/model.ex
@@ -1,0 +1,604 @@
+defmodule EMLXAxon.Llama.Model do
+  @moduledoc """
+  Llama model state struct and forward pass for native dense weights.
+
+  ## Native dense strategy
+
+  The dense native generation path uses dedicated EMLX Llama primitives for
+  layer execution, final greedy selection, and chunked decode. The generic
+  tensor path remains available as a fallback for unsupported samplers.
+
+  GPU sync: greedy paths evaluate at the native sampler boundary. Deferred host
+  sync modes keep generated token tensors on the EMLX backend until the end of
+  the request or the next configured chunk.
+  """
+
+  alias EMLXAxon.Llama.{Rope, Sampler}
+
+  @type layer ::
+          {Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t(),
+           Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t(), Nx.Tensor.t()}
+
+  defmodule State do
+    @moduledoc "Loaded model weights and config."
+
+    @enforce_keys [:embed_tokens, :layers, :norm, :lm_head, :rope_freqs, :config]
+    defstruct [:embed_tokens, :layers, :norm, :lm_head, :rope_freqs, :config]
+
+    @type t :: %__MODULE__{
+            embed_tokens: Nx.Tensor.t(),
+            layers: [EMLXAxon.Llama.Model.layer()],
+            norm: Nx.Tensor.t(),
+            lm_head: Nx.Tensor.t(),
+            rope_freqs: Nx.Tensor.t(),
+            config: map()
+          }
+  end
+
+  @doc false
+  def layer(
+        input_layernorm,
+        post_attention_layernorm,
+        q_proj,
+        k_proj,
+        v_proj,
+        o_proj,
+        gate_proj,
+        up_proj,
+        down_proj
+      ) do
+    {
+      input_layernorm,
+      post_attention_layernorm,
+      q_proj,
+      k_proj,
+      v_proj,
+      o_proj,
+      gate_proj,
+      up_proj,
+      down_proj
+    }
+  end
+
+  @doc """
+  Initialise a preallocated KV cache for all layers.
+
+  Returns a list of `{k_cache, v_cache}` pairs, one per transformer layer,
+  where each cache is pre-allocated to `max_len` positions.
+  """
+  @spec init_kv_cache(State.t(), pos_integer()) :: [{Nx.Tensor.t(), Nx.Tensor.t()}]
+  def init_kv_cache(%State{config: cfg, layers: layers} = state, max_len) do
+    num_kv_heads = cfg.num_key_value_heads
+    head_dim = cfg.head_dim
+    cache_type = cache_type!(state)
+
+    # Cache layout: {B, N_kv, max_len, D} — heads-before-sequence so that
+    # tensors transposed to {B, N, T, D} for RoPE/SDPA slot in without copies.
+    for _layer <- layers do
+      k =
+        0.0
+        |> EMLX.full({1, num_kv_heads, max_len, head_dim}, cache_type, :gpu)
+        |> EMLX.Backend.to_nx()
+
+      v =
+        0.0
+        |> EMLX.full({1, num_kv_heads, max_len, head_dim}, cache_type, :gpu)
+        |> EMLX.Backend.to_nx()
+
+      {k, v}
+    end
+  end
+
+  @doc """
+  Initialise a native KV cache for dense greedy generation.
+
+  This returns raw EMLX tensor refs instead of wrapping each cache buffer as an
+  `%Nx.Tensor{}`. The native greedy Llama NIFs accept this shape directly.
+  Unsupported states fall back to `init_kv_cache/2`.
+  """
+  @spec init_native_kv_cache(State.t(), pos_integer()) :: kv_cache()
+  def init_native_kv_cache(%State{} = state, max_len) do
+    if native_forward_greedy?(state) do
+      %State{config: cfg, layers: layers} = state
+      num_kv_heads = cfg.num_key_value_heads
+      head_dim = cfg.head_dim
+      cache_type = cache_type!(state)
+
+      for _layer <- layers do
+        k = EMLX.full(0.0, {1, num_kv_heads, max_len, head_dim}, cache_type, :gpu)
+        v = EMLX.full(0.0, {1, num_kv_heads, max_len, head_dim}, cache_type, :gpu)
+        {k, v}
+      end
+    else
+      init_kv_cache(state, max_len)
+    end
+  end
+
+  @doc """
+  Full forward pass for a single decode step.
+
+  - `input_ids` — `{1, seq_len}` integer tensor (the prompt or latest token)
+  - `kv_cache`  — list of `{k_cache, v_cache}` preallocated tensors
+  - `current_len` — number of tokens already written into the KV cache
+
+  Returns `{logits, kv_cache_updated}` where logits has shape `{1, vocab_size}`.
+  The cache is updated in-place via `Nx.put_slice`; `kv_cache_updated` is the
+  same list with updated slices.
+  """
+  @spec forward(Nx.Tensor.t(), [{Nx.Tensor.t(), Nx.Tensor.t()}], non_neg_integer(), State.t()) ::
+          {Nx.Tensor.t(), [{Nx.Tensor.t(), Nx.Tensor.t()}]}
+  def forward(input_ids, kv_cache, current_len, %State{} = state) do
+    {hidden, kv_cache_updated} = forward_hidden(input_ids, kv_cache, current_len, state)
+
+    %State{norm: norm, lm_head: lm_head, config: cfg} = state
+    logits = final_logits(hidden, input_ids, norm, lm_head, cfg)
+
+    {logits, kv_cache_updated}
+  end
+
+  @doc """
+  Full forward pass for greedy generation.
+
+  This returns the selected token id tensor directly and is only used for the
+  dense native greedy path. Samplers other than greedy still use `forward/4` so
+  they can inspect logits.
+  """
+  @type kv_cache :: [{Nx.Tensor.t() | EMLX.tensor_ref(), Nx.Tensor.t() | EMLX.tensor_ref()}]
+
+  @spec forward_greedy(Nx.Tensor.t(), kv_cache(), non_neg_integer(), State.t()) ::
+          {Nx.Tensor.t(), kv_cache()}
+  def forward_greedy(input_ids, kv_cache, current_len, %State{} = state) do
+    if native_forward_greedy?(state) do
+      forward_native_greedy(input_ids, kv_cache, current_len, state)
+    else
+      {hidden, kv_cache_updated} = forward_hidden(input_ids, kv_cache, current_len, state)
+
+      %State{norm: norm, lm_head: lm_head, config: cfg} = state
+      token = final_greedy(hidden, input_ids, norm, lm_head, cfg)
+
+      {token, kv_cache_updated}
+    end
+  end
+
+  defp forward_greedy_token_id(input_ids, kv_cache, current_len, %State{} = state) do
+    if native_forward_greedy?(state) do
+      forward_native_greedy_token_id(input_ids, kv_cache, current_len, state)
+    else
+      {token, kv_cache} = forward_greedy(input_ids, kv_cache, current_len, state)
+      {Nx.to_number(token), kv_cache}
+    end
+  end
+
+  @doc """
+  Greedy decode from one host token id.
+
+  Native dense Llama can pass the token id directly to EMLX and avoid building
+  a CPU `Nx.Tensor` plus backend transfer for every decode step. Other states
+  fall back to the regular tensor based path.
+  """
+  @spec forward_greedy_decode_token_id(
+          non_neg_integer(),
+          kv_cache(),
+          non_neg_integer(),
+          State.t()
+        ) ::
+          {non_neg_integer(), kv_cache()}
+  def forward_greedy_decode_token_id(token_id, kv_cache, current_len, %State{} = state) do
+    if native_forward_greedy?(state) do
+      forward_native_greedy_decode_token_id(token_id, kv_cache, current_len, state)
+    else
+      input_ids = Nx.tensor([[token_id]], type: :s64, backend: Nx.BinaryBackend)
+      forward_greedy_token_id(input_ids, kv_cache, current_len, state)
+    end
+  end
+
+  @doc """
+  Runs multiple dense greedy decode steps in one native call.
+
+  This is used by chunked host sync for generation without streaming. It keeps the
+  generated token tensors on the EMLX backend and returns the final KV cache,
+  avoiding one Elixir/NIF boundary crossing per decoded token.
+  """
+  @spec forward_greedy_chunk(
+          Nx.Tensor.t(),
+          kv_cache(),
+          non_neg_integer(),
+          pos_integer(),
+          State.t()
+        ) ::
+          {[Nx.Tensor.t()], kv_cache()} | :fallback
+  def forward_greedy_chunk(input_ids, kv_cache, current_len, count, %State{} = state)
+      when is_integer(count) and count > 0 do
+    if native_forward_greedy?(state) do
+      forward_native_greedy_chunk(input_ids, kv_cache, current_len, count, state)
+    else
+      :fallback
+    end
+  end
+
+  defp forward_hidden(input_ids, kv_cache, current_len, %State{} = state) do
+    %State{embed_tokens: embed_tokens, layers: layers, rope_freqs: rope_freqs, config: cfg} =
+      state
+
+    hidden = embed_input(input_ids, embed_tokens)
+
+    {hidden, kv_cache_rev} =
+      if cfg[:dense_layers?] do
+        # Dense state: avoid quantization checks for every layer and repeated
+        # attention constant calculation in the decode hot path.
+        forward_dense_layers(
+          layers,
+          kv_cache,
+          hidden,
+          [],
+          current_len,
+          dense_layer_ctx(cfg, rope_freqs)
+        )
+      else
+        # Walk layers + KV pairs without Enum.zip to avoid an extra list allocation per forward.
+        forward_layers(layers, kv_cache, hidden, [], current_len, cfg)
+      end
+
+    kv_cache_updated = :lists.reverse(kv_cache_rev)
+
+    {hidden, kv_cache_updated}
+  end
+
+  defp embed_input(input_ids, embed_tokens) do
+    ids_shape = Nx.shape(input_ids)
+
+    if elem(ids_shape, 1) == 1 do
+      # Decode hot path (single token): avoid a slice graph over the full row when T==1.
+      Nx.take(embed_tokens, Nx.reshape(input_ids[[0, 0]], {1})) |> Nx.new_axis(0)
+    else
+      Nx.take(embed_tokens, input_ids[[0, ..]]) |> Nx.new_axis(0)
+    end
+  end
+
+  defp native_forward_greedy?(%State{config: cfg, lm_head: lm_head}),
+    do: cfg[:dense_layers?] == true and not EMLX.Quantization.quantized?(lm_head)
+
+  defp cache_type!(%State{embed_tokens: embed_tokens}) do
+    case Nx.type(embed_tokens) do
+      {:f, 16} -> :float16
+      {:bf, 16} -> :bfloat16
+      {:f, 32} -> :float32
+      type -> raise ArgumentError, "unsupported Llama KV cache tensor type: #{inspect(type)}"
+    end
+  end
+
+  defp forward_native_greedy(input_ids, kv_cache, current_len, %State{} = state) do
+    %State{
+      embed_tokens: embed_tokens,
+      layers: layers,
+      norm: norm,
+      lm_head: lm_head,
+      rope_freqs: rope_freqs,
+      config: cfg
+    } =
+      state
+
+    {head_dim, scale, rope_freqs, eps} = dense_layer_ctx(cfg, rope_freqs)
+    embed_ref = EMLX.Backend.from_nx(embed_tokens)
+    rope_freqs_ref = EMLX.Backend.from_nx(rope_freqs)
+
+    {token_ref, kv_cache_refs} =
+      EMLX.Native.Llama.forward_greedy_ids(
+        input_ids_ref(input_ids, embed_ref),
+        embed_ref,
+        layers,
+        kv_cache,
+        EMLX.Backend.from_nx(norm),
+        EMLX.Backend.from_nx(lm_head),
+        current_len,
+        scale,
+        head_dim,
+        rope_freqs_ref,
+        eps
+      )
+
+    token =
+      token_ref
+      |> EMLX.Backend.to_nx()
+      |> Nx.squeeze(axes: [0])
+
+    {token, kv_cache_refs}
+  end
+
+  defp forward_native_greedy_token_id(input_ids, kv_cache, current_len, %State{} = state) do
+    %State{
+      embed_tokens: embed_tokens,
+      layers: layers,
+      norm: norm,
+      lm_head: lm_head,
+      rope_freqs: rope_freqs,
+      config: cfg
+    } =
+      state
+
+    {head_dim, scale, rope_freqs, eps} = dense_layer_ctx(cfg, rope_freqs)
+    embed_ref = EMLX.Backend.from_nx(embed_tokens)
+    rope_freqs_ref = EMLX.Backend.from_nx(rope_freqs)
+
+    {token_id, kv_cache_refs} =
+      EMLX.Native.Llama.forward_greedy_ids_token_id(
+        input_ids_ref(input_ids, embed_ref),
+        embed_ref,
+        layers,
+        kv_cache,
+        EMLX.Backend.from_nx(norm),
+        EMLX.Backend.from_nx(lm_head),
+        current_len,
+        scale,
+        head_dim,
+        rope_freqs_ref,
+        eps
+      )
+
+    {token_id, kv_cache_refs}
+  end
+
+  defp forward_native_greedy_decode_token_id(token_id, kv_cache, current_len, %State{} = state) do
+    %State{
+      embed_tokens: embed_tokens,
+      layers: layers,
+      norm: norm,
+      lm_head: lm_head,
+      rope_freqs: rope_freqs,
+      config: cfg
+    } =
+      state
+
+    {head_dim, scale, rope_freqs, eps} = dense_layer_ctx(cfg, rope_freqs)
+    embed_ref = EMLX.Backend.from_nx(embed_tokens)
+    rope_freqs_ref = EMLX.Backend.from_nx(rope_freqs)
+
+    {next_token_id, kv_cache_refs} =
+      EMLX.Native.Llama.forward_greedy_token_id(
+        token_id,
+        embed_ref,
+        layers,
+        kv_cache,
+        EMLX.Backend.from_nx(norm),
+        EMLX.Backend.from_nx(lm_head),
+        current_len,
+        scale,
+        head_dim,
+        rope_freqs_ref,
+        eps
+      )
+
+    {next_token_id, kv_cache_refs}
+  end
+
+  defp forward_native_greedy_chunk(input_ids, kv_cache, current_len, count, %State{} = state) do
+    %State{
+      embed_tokens: embed_tokens,
+      layers: layers,
+      norm: norm,
+      lm_head: lm_head,
+      rope_freqs: rope_freqs,
+      config: cfg
+    } =
+      state
+
+    {head_dim, scale, rope_freqs, eps} = dense_layer_ctx(cfg, rope_freqs)
+    embed_ref = EMLX.Backend.from_nx(embed_tokens)
+    rope_freqs_ref = EMLX.Backend.from_nx(rope_freqs)
+
+    {token_refs, kv_cache_refs} =
+      EMLX.Native.Llama.forward_greedy_ids_chunk(
+        input_ids_ref(input_ids, embed_ref),
+        embed_ref,
+        layers,
+        kv_cache,
+        EMLX.Backend.from_nx(norm),
+        EMLX.Backend.from_nx(lm_head),
+        current_len,
+        count,
+        scale,
+        head_dim,
+        rope_freqs_ref,
+        eps
+      )
+
+    tokens =
+      Enum.map(token_refs, fn token_ref ->
+        token_ref
+        |> EMLX.Backend.to_nx()
+        |> Nx.squeeze(axes: [0])
+      end)
+
+    {tokens, kv_cache_refs}
+  end
+
+  defp input_ids_ref(%Nx.Tensor{data: %EMLX.Backend{ref: {device, ref}}}, {device, _ref}) do
+    {device, ref}
+  end
+
+  defp input_ids_ref(input_ids, {device, _ref}) do
+    input_ids
+    |> Nx.backend_transfer({EMLX.Backend, device: device})
+    |> EMLX.Backend.from_nx()
+  end
+
+  defp final_logits(hidden, input_ids, norm, lm_head, cfg) do
+    ids_shape = Nx.shape(input_ids)
+
+    # Final norm + lm_head on the last token position only
+    last_hidden =
+      if elem(ids_shape, 1) == 1 do
+        Nx.squeeze(hidden, axes: [1])
+      else
+        hidden[[.., -1, ..]]
+      end
+
+    normed = EMLX.Fast.rms_norm(last_hidden, norm, cfg.rms_norm_eps)
+    Nx.dot(normed, [1], lm_head, [1])
+  end
+
+  defp final_greedy(hidden, input_ids, norm, lm_head, cfg) do
+    if EMLX.Quantization.quantized?(lm_head) do
+      hidden
+      |> final_logits(input_ids, norm, lm_head, cfg)
+      |> Sampler.greedy()
+    else
+      hidden
+      |> EMLX.Backend.from_nx()
+      |> EMLX.Native.Llama.final_greedy(
+        EMLX.Backend.from_nx(norm),
+        EMLX.Backend.from_nx(lm_head),
+        cfg.rms_norm_eps
+      )
+      |> EMLX.Backend.to_nx()
+      |> Nx.squeeze(axes: [0])
+    end
+  end
+
+  defp forward_layers([], [], hidden, acc, _cur_len, _cfg), do: {hidden, acc}
+
+  defp forward_layers(
+         [layer_weights | layers_rest],
+         [{k_cache, v_cache} | kv_rest],
+         hidden,
+         acc,
+         cur_len,
+         cfg
+       ) do
+    {h_new, k_new, v_new} =
+      transformer_layer(hidden, k_cache, v_cache, cur_len, layer_weights, cfg)
+
+    forward_layers(layers_rest, kv_rest, h_new, [{k_new, v_new} | acc], cur_len, cfg)
+  end
+
+  defp dense_layer_ctx(cfg, rope_freqs) do
+    head_dim = cfg.head_dim
+    {head_dim, 1.0 / :math.sqrt(head_dim), rope_freqs, cfg.rms_norm_eps}
+  end
+
+  defp forward_dense_layers([], [], hidden, acc, _cur_len, _ctx), do: {hidden, acc}
+
+  defp forward_dense_layers(
+         [layer_weights | layers_rest],
+         [{k_cache, v_cache} | kv_rest],
+         hidden,
+         acc,
+         cur_len,
+         ctx
+       ) do
+    {h_new, k_new, v_new} =
+      dense_transformer_layer(hidden, k_cache, v_cache, cur_len, layer_weights, ctx)
+
+    forward_dense_layers(layers_rest, kv_rest, h_new, [{k_new, v_new} | acc], cur_len, ctx)
+  end
+
+  @doc false
+  def transformer_layer(
+        hidden,
+        k_cache,
+        v_cache,
+        current_len,
+        {norm1, norm2, q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj},
+        cfg
+      ) do
+    layer(
+      hidden,
+      norm1,
+      q_proj,
+      k_proj,
+      v_proj,
+      o_proj,
+      gate_proj,
+      up_proj,
+      down_proj,
+      norm2,
+      k_cache,
+      v_cache,
+      current_len,
+      cfg
+    )
+  end
+
+  defp layer(
+         hidden,
+         norm1,
+         q_proj,
+         k_proj,
+         v_proj,
+         o_proj,
+         gate_proj,
+         up_proj,
+         down_proj,
+         norm2,
+         k_cache,
+         v_cache,
+         current_len,
+         cfg
+       ) do
+    head_dim = cfg.head_dim
+    scale = 1.0 / :math.sqrt(head_dim)
+
+    {hidden_ref, k_cache_ref, v_cache_ref} =
+      EMLX.Native.Llama.layer(
+        EMLX.Backend.from_nx(hidden),
+        EMLX.Backend.from_nx(norm1),
+        EMLX.Backend.from_nx(q_proj),
+        EMLX.Backend.from_nx(k_proj),
+        EMLX.Backend.from_nx(v_proj),
+        EMLX.Backend.from_nx(o_proj),
+        EMLX.Backend.from_nx(k_cache),
+        EMLX.Backend.from_nx(v_cache),
+        EMLX.Backend.from_nx(norm2),
+        EMLX.Backend.from_nx(gate_proj),
+        EMLX.Backend.from_nx(up_proj),
+        EMLX.Backend.from_nx(down_proj),
+        current_len,
+        scale,
+        head_dim,
+        EMLX.Backend.from_nx(Rope.freqs_from_config!(cfg)),
+        cfg.rms_norm_eps
+      )
+
+    {
+      EMLX.Backend.to_nx(hidden_ref),
+      EMLX.Backend.to_nx(k_cache_ref),
+      EMLX.Backend.to_nx(v_cache_ref)
+    }
+  end
+
+  defp dense_transformer_layer(
+         hidden,
+         k_cache,
+         v_cache,
+         current_len,
+         {norm1, norm2, q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj},
+         {head_dim, scale, rope_freqs, eps}
+       ) do
+    {hidden_ref, k_cache_ref, v_cache_ref} =
+      EMLX.Native.Llama.layer(
+        EMLX.Backend.from_nx(hidden),
+        EMLX.Backend.from_nx(norm1),
+        EMLX.Backend.from_nx(q_proj),
+        EMLX.Backend.from_nx(k_proj),
+        EMLX.Backend.from_nx(v_proj),
+        EMLX.Backend.from_nx(o_proj),
+        EMLX.Backend.from_nx(k_cache),
+        EMLX.Backend.from_nx(v_cache),
+        EMLX.Backend.from_nx(norm2),
+        EMLX.Backend.from_nx(gate_proj),
+        EMLX.Backend.from_nx(up_proj),
+        EMLX.Backend.from_nx(down_proj),
+        current_len,
+        scale,
+        head_dim,
+        EMLX.Backend.from_nx(rope_freqs),
+        eps
+      )
+
+    {
+      EMLX.Backend.to_nx(hidden_ref),
+      EMLX.Backend.to_nx(k_cache_ref),
+      EMLX.Backend.to_nx(v_cache_ref)
+    }
+  end
+end

--- a/emlx_axon/lib/emlx_axon/llama/rope.ex
+++ b/emlx_axon/lib/emlx_axon/llama/rope.ex
@@ -1,0 +1,79 @@
+defmodule EMLXAxon.Llama.Rope do
+  @moduledoc false
+
+  @gpu {EMLX.Backend, device: :gpu}
+
+  @spec freqs_from_config!(map()) :: Nx.Tensor.t()
+  def freqs_from_config!(config) do
+    head_dim = Map.fetch!(config, :head_dim)
+    theta = Map.get(config, :rope_theta, 10_000.0)
+    scaling = Map.get(config, :rope_scaling)
+
+    freqs =
+      case scaling do
+        nil ->
+          head_dim
+          |> base_inv_freqs(theta)
+          |> mlx_freqs_from_inv_freqs()
+
+        %{type: :llama3} = opts ->
+          opts
+          |> llama3_inv_freqs(head_dim, theta)
+          |> mlx_freqs_from_inv_freqs()
+
+        other ->
+          raise ArgumentError,
+                "native dense Llama generation supports nil or :llama3 rope scaling, got: #{inspect(other)}"
+      end
+
+    Nx.backend_transfer(freqs, @gpu)
+  end
+
+  defp base_inv_freqs(head_dim, theta) do
+    dims = div(head_dim, 2)
+
+    range =
+      Nx.iota({dims}, type: :f32)
+      |> Nx.multiply(2.0)
+      |> Nx.divide(head_dim)
+
+    Nx.divide(1.0, Nx.pow(theta, range))
+  end
+
+  defp llama3_inv_freqs(opts, head_dim, theta) do
+    factor = Map.get(opts, :factor, 8.0)
+    low_frequency_factor = Map.get(opts, :low_frequency_factor, 1.0)
+    high_frequency_factor = Map.get(opts, :high_frequency_factor, 4.0)
+    original_max_positions = Map.get(opts, :original_max_positions, 8_192)
+
+    inv_freq = base_inv_freqs(head_dim, theta)
+    wavelength = Nx.multiply(2.0 * :math.pi(), Nx.divide(1.0, inv_freq))
+
+    low_frequency_wavelength = original_max_positions / low_frequency_factor
+    high_frequency_wavelength = original_max_positions / high_frequency_factor
+
+    smooth_factor =
+      original_max_positions
+      |> Nx.divide(wavelength)
+      |> Nx.subtract(low_frequency_factor)
+      |> Nx.divide(high_frequency_factor - low_frequency_factor)
+
+    smoothed =
+      Nx.add(
+        Nx.multiply(Nx.subtract(1.0, smooth_factor), Nx.divide(inv_freq, factor)),
+        Nx.multiply(smooth_factor, inv_freq)
+      )
+
+    Nx.select(
+      Nx.less(wavelength, high_frequency_wavelength),
+      inv_freq,
+      Nx.select(
+        Nx.greater(wavelength, low_frequency_wavelength),
+        Nx.divide(inv_freq, factor),
+        smoothed
+      )
+    )
+  end
+
+  defp mlx_freqs_from_inv_freqs(inv_freqs), do: Nx.divide(1.0, inv_freqs)
+end

--- a/emlx_axon/lib/emlx_axon/llama/sampler.ex
+++ b/emlx_axon/lib/emlx_axon/llama/sampler.ex
@@ -1,0 +1,128 @@
+defmodule EMLXAxon.Llama.Sampler do
+  @moduledoc """
+  Three sampling strategies for autoregressive token generation.
+
+  All functions accept `logits` of shape `{1, vocab_size}` and return a
+  scalar integer tensor (the sampled token id).
+
+  - `greedy/1`     — deterministic argmax, fastest
+  - `top_p_cpu/3`  — faithful port of bobby_posts: logits → CPU → sort → sample
+  - `top_p_gpu/2`  — `defn`-compiled temperature sampling on the GPU; avoids
+    the host transfer
+  """
+
+  import Nx.Defn
+
+  @doc "Greedy decoding: return the token with the highest logit as a scalar tensor."
+  def greedy(logits) do
+    logits |> Nx.squeeze(axes: [0]) |> Nx.argmax(axis: 0)
+  end
+
+  @doc """
+  CPU top-p (nucleus) sampler — faithful port of bobby_posts.
+
+  Transfers the full vocabulary logits to the BEAM for sort + sample.
+  This matches the A0 baseline timing (expected ~42 ms overhead per token).
+  """
+  def top_p_cpu(logits, temperature \\ 0.95, top_p \\ 0.9) do
+    validate_temperature!(temperature)
+    validate_top_p!(top_p)
+
+    shape = Nx.shape(logits)
+    vocab_size = elem(shape, tuple_size(shape) - 1)
+
+    # Scale by temperature then softmax on the host
+    scaled = Nx.divide(logits, temperature) |> Nx.to_flat_list()
+
+    max_l = Enum.max(scaled)
+    exps = Enum.map(scaled, fn l -> :math.exp(l - max_l) end)
+    sum_e = Enum.sum(exps)
+    probs = Enum.map(exps, &(&1 / sum_e))
+
+    # Sort descending by probability
+    indexed = Enum.zip(0..(vocab_size - 1), probs)
+    sorted = Enum.sort_by(indexed, fn {_i, p} -> p end, :desc)
+
+    # Nucleus cutoff
+    {chosen, _cum} =
+      Enum.reduce_while(sorted, {[], 0.0}, fn {idx, p}, {acc, cum} ->
+        new_cum = cum + p
+
+        if new_cum - p >= top_p do
+          {:halt, {acc, cum}}
+        else
+          {:cont, {[{idx, p} | acc], new_cum}}
+        end
+      end)
+
+    candidates = Enum.reverse(chosen)
+
+    # Re-normalise and sample
+    total = Enum.sum(Enum.map(candidates, fn {_i, p} -> p end))
+    normed = Enum.map(candidates, fn {i, p} -> {i, p / total} end)
+
+    u = :rand.uniform()
+    token = sample_from_probs(normed, u, 0.0)
+
+    Nx.tensor(token, type: :s64)
+  end
+
+  defp sample_from_probs([], _u, _acc), do: 0
+
+  defp sample_from_probs([{idx, p} | rest], u, acc) do
+    new_acc = acc + p
+    if new_acc >= u, do: idx, else: sample_from_probs(rest, u, new_acc)
+  end
+
+  @doc """
+  GPU temperature sampler compiled with `defn`.
+
+  Uses the Gumbel-max trick: `argmax(logits/temp + Gumbel_noise)` draws a
+  sample proportional to `softmax(logits/temp)`. This is mathematically
+  equivalent to categorical sampling without any vocabulary-wide sort, which
+  avoids the MLX argsort kernel limitation at vocab_size=151936.
+
+  Note: this implements temperature sampling without nucleus (top-p) cutoff.
+  The top-p filtering requires argsort of a 151k-element tensor, which hits
+  an unsupported MLX Metal kernel for this vocab size. Temperature sampling
+  achieves similar randomisation and benchmarks the GPU sampler path.
+
+  `key` must be a `Nx.Random.key/1` value passed as a positional argument
+  (not through opts) so defn can trace it correctly.
+
+  ## Options
+  - `:temperature` — float, default 0.95
+  """
+  def top_p_gpu(logits, key, opts \\ []) do
+    temperature = Keyword.get(opts, :temperature, 0.95)
+    validate_temperature!(temperature)
+    top_p_gpu_defn(logits, key, temperature)
+  end
+
+  defn top_p_gpu_defn(logits, key, temperature) do
+    logits_1d = Nx.squeeze(logits)
+
+    # Gumbel noise: G = -log(-log(U)) where U ~ Uniform(0, 1)
+    {u, _key} = Nx.Random.uniform(key, shape: Nx.shape(logits_1d), type: :f32)
+    gumbel = Nx.negate(Nx.log(Nx.negate(Nx.log(u + 1.0e-10)) + 1.0e-10))
+
+    # argmax(logits/temp + Gumbel) ~ Categorical(softmax(logits/temp))
+    Nx.argmax(logits_1d / temperature + gumbel, axis: 0)
+  end
+
+  defp validate_temperature!(temperature) when is_number(temperature) and temperature > 0,
+    do: :ok
+
+  defp validate_temperature!(temperature) do
+    raise ArgumentError,
+          "expected temperature to be a positive number, got: #{inspect(temperature)}"
+  end
+
+  defp validate_top_p!(top_p) when is_number(top_p) and top_p > 0 and top_p <= 1,
+    do: :ok
+
+  defp validate_top_p!(top_p) do
+    raise ArgumentError,
+          "expected top_p to be a number greater than 0.0 and less than or equal to 1.0, got: #{inspect(top_p)}"
+  end
+end

--- a/emlx_axon/lib/emlx_axon/text_generation.ex
+++ b/emlx_axon/lib/emlx_axon/text_generation.ex
@@ -1,11 +1,10 @@
 defmodule EMLXAxon.TextGeneration do
   @moduledoc """
-  A `Nx.Serving`-compatible wrapper around native Qwen3 generation.
+  A `Nx.Serving`-compatible wrapper around native EMLXAxon text generation.
 
-  Bypasses the Axon graph entirely — the 28-layer forward pass runs as a single
-  `mlx::eval` per token (via `EMLXAxon.Qwen3.Generate`), avoiding
-  the 28 separate Metal command buffer submissions that the Bumblebee + Axon path
-  incurs.
+  Bypasses the Axon graph entirely and dispatches to the native generator for
+  the loaded model family. Supported states currently come from
+  `EMLXAxon.Qwen3` and `EMLXAxon.Llama`.
 
   Only Bumblebee tokenization is used from upstream Bumblebee. No Bumblebee model
   function or Axon graph is involved in the decode forward pass.
@@ -41,7 +40,8 @@ defmodule EMLXAxon.TextGeneration do
       IO.puts(result.results |> hd() |> Map.fetch!(:generated_text))
   """
 
-  alias EMLXAxon.Qwen3.{Model, Generate, Loader}
+  alias EMLXAxon.{Llama, Qwen3}
+  alias EMLXAxon.Qwen3.Loader
 
   @cpu_backend Nx.BinaryBackend
   @decode_cache_table __MODULE__.DecodeCache
@@ -49,16 +49,19 @@ defmodule EMLXAxon.TextGeneration do
   @default_stream_host_sync {:chunk, 5}
 
   @doc """
-  Runs native Qwen3 text generation directly, without wrapping the call in
+  Runs native text generation directly, without wrapping the call in
   `Nx.Serving`.
 
   This is useful for host applications that already own a loaded
-  `EMLXAxon.Qwen3.Model.State` and want to avoid serving preprocessing
-  overhead. The return shape matches `serving/3` for the same `:output_format`.
+  `EMLXAxon.Qwen3.Model.State` or `EMLXAxon.Llama.Model.State` and want to avoid
+  serving preprocessing overhead. The return shape matches `serving/3` for the
+  same `:output_format`.
   """
-  def run(tokenizer, %Model.State{} = state, input, opts \\ []) do
+  def run(tokenizer, state, input, opts \\ []) do
+    ensure_supported_state!(state)
+
     max_new = max_new_tokens!(opts, 100)
-    configured_max_len = Keyword.get(opts, :max_len, 2048)
+    configured_max_len = max_len!(opts, 2048)
     sampler = Keyword.get(opts, :sampler, :greedy)
     profile_timing = Keyword.get(opts, :profile_timing, false)
     output_format = Keyword.get(opts, :output_format, :native)
@@ -83,7 +86,7 @@ defmodule EMLXAxon.TextGeneration do
       kv_cache_for_request(opts, state, configured_max_len, input_length, max_new, sampler)
 
     {tokens, metadata} =
-      Generate.generate(input_ids, state,
+      generate_module(state).generate(input_ids, state,
         kv_cache: kv_cache,
         max_new_tokens: max_new,
         max_len: max_len,
@@ -143,10 +146,24 @@ defmodule EMLXAxon.TextGeneration do
   end
 
   defp init_kv_cache_for_sampler(state, max_len, :greedy),
-    do: Model.init_native_kv_cache(state, max_len)
+    do: model_module(state).init_native_kv_cache(state, max_len)
 
   defp init_kv_cache_for_sampler(state, max_len, _sampler),
-    do: Model.init_kv_cache(state, max_len)
+    do: model_module(state).init_kv_cache(state, max_len)
+
+  defp ensure_supported_state!(%Qwen3.Model.State{}), do: :ok
+  defp ensure_supported_state!(%Llama.Model.State{}), do: :ok
+
+  defp ensure_supported_state!(state) do
+    raise ArgumentError,
+          "expected a Qwen3 or Llama native model state, got: #{inspect(state)}"
+  end
+
+  defp model_module(%Qwen3.Model.State{}), do: Qwen3.Model
+  defp model_module(%Llama.Model.State{}), do: Llama.Model
+
+  defp generate_module(%Qwen3.Model.State{}), do: Qwen3.Generate
+  defp generate_module(%Llama.Model.State{}), do: Llama.Generate
 
   defp adaptive_max_len(configured_max_len, input_length, max_new) do
     min(configured_max_len, input_length + max(max_new, 1) - 1)
@@ -181,7 +198,7 @@ defmodule EMLXAxon.TextGeneration do
   defp stream_host_sync_mode(other, _sampler), do: other
 
   @doc """
-  Streams native Qwen3 text generation through `emit_fun`.
+  Streams native text generation through `emit_fun`.
 
   `emit_fun` is called with decoded text chunks as they become available. The
   function returns a map with `:token_summary`, matching the shape used by
@@ -204,10 +221,12 @@ defmodule EMLXAxon.TextGeneration do
     the response. Samplers that cannot use deferred host sync fall back to
     emitting each token.
   """
-  def stream(tokenizer, %Model.State{} = state, input, emit_fun, opts \\ [])
+  def stream(tokenizer, state, input, emit_fun, opts \\ [])
       when is_function(emit_fun, 1) do
+    ensure_supported_state!(state)
+
     max_new = max_new_tokens!(opts, 100)
-    configured_max_len = Keyword.get(opts, :max_len, 2048)
+    configured_max_len = max_len!(opts, 2048)
     sampler = Keyword.get(opts, :sampler, :greedy)
     profile_timing = Keyword.get(opts, :profile_timing, false)
     temperature = Keyword.get(opts, :temperature, 0.95)
@@ -278,15 +297,17 @@ defmodule EMLXAxon.TextGeneration do
   end
 
   @doc """
-  Builds an `Nx.Serving` wrapping a native Qwen3 model state.
+  Builds an `Nx.Serving` wrapping a native model state.
 
   The state may come from the MLX-4bit loader or from
-  `EMLXAxon.Qwen3.DenseLoader` for standard dense Hugging Face safetensors.
+  `EMLXAxon.Qwen3.DenseLoader` or `EMLXAxon.Llama.DenseLoader` for standard
+  dense Hugging Face safetensors.
 
   Accepts the same text-string input format as `Bumblebee.Text.generation/4`:
-  a plain binary or `%{text: binary()}`. Returns `%{results: [%{generated_text: binary(),
-  num_tokens: pos_integer()}]}`. Native Qwen3 generation currently supports
-  one input at a time; list/batch inputs raise `ArgumentError`.
+  a plain binary or `%{text: binary()}`. Returns
+  `%{results: [%{generated_text: binary(), num_tokens: pos_integer()}],
+  finish_reason: :stop | :length}`. Native generation currently supports one
+  input at a time; list/batch inputs raise `ArgumentError`.
 
   ## Options
 
@@ -310,8 +331,10 @@ defmodule EMLXAxon.TextGeneration do
                         compatible with `Bumblebee.Text.generation/4` (default `:native`)
   """
   def serving(tokenizer, state, opts \\ []) do
+    ensure_supported_state!(state)
+
     max_new = max_new_tokens!(opts, 100)
-    configured_max_len = Keyword.get(opts, :max_len, 2048)
+    configured_max_len = max_len!(opts, 2048)
     sampler = Keyword.get(opts, :sampler, :greedy)
     temperature = Keyword.get(opts, :temperature, 0.95)
     top_p = Keyword.get(opts, :top_p, 0.9)
@@ -335,8 +358,8 @@ defmodule EMLXAxon.TextGeneration do
         max_len = adaptive_max_len(configured_max_len, input_length, max_new)
         kv_cache = init_kv_cache_for_sampler(state, max_len, sampler)
 
-        {tokens, _timing} =
-          Generate.generate(input_ids, state,
+        {tokens, generation_metadata} =
+          generate_module(state).generate(input_ids, state,
             kv_cache: kv_cache,
             max_new_tokens: max_new,
             max_len: max_len,
@@ -349,7 +372,7 @@ defmodule EMLXAxon.TextGeneration do
 
         # Return as 2-D tensor {1, num_tokens} matching the shape that
         # Bumblebee.Tokenizer.decode/2 expects for batch input.
-        tokens_to_batch_tensor(tokens)
+        serving_output(tokens, generation_metadata)
       end
     end)
     |> Nx.Serving.client_preprocessing(fn input ->
@@ -370,14 +393,52 @@ defmodule EMLXAxon.TextGeneration do
 
       {Nx.Batch.concatenate([%{"input_ids" => input_ids}]), input_length}
     end)
-    |> Nx.Serving.client_postprocessing(fn {token_ids, _metadata}, input_length ->
+    |> Nx.Serving.client_postprocessing(fn {%{token_ids: token_ids} = generation_output,
+                                            _metadata},
+                                           input_length ->
       # token_ids: {1, num_generated_tokens} on Nx.BinaryBackend
       num_tokens = elem(Nx.shape(token_ids), 1)
       decoded = Bumblebee.Tokenizer.decode(tokenizer, token_ids)
 
       %{results: [result(decoded_text(decoded), input_length, num_tokens, output_format)]}
+      |> maybe_put_serving_finish_reason(generation_output)
     end)
   end
+
+  defp serving_output(tokens, generation_metadata) do
+    %{
+      token_ids: tokens_to_batch_tensor(tokens),
+      finish_reason: serving_finish_reason(generation_metadata)
+    }
+  end
+
+  defp serving_finish_reason(%{finish_reason: finish_reason}) do
+    Nx.tensor([finish_reason_code(finish_reason)], type: :s64)
+  end
+
+  defp serving_finish_reason(_metadata) do
+    Nx.tensor([finish_reason_code(:length)], type: :s64)
+  end
+
+  defp maybe_put_serving_finish_reason(output, %{finish_reason: finish_reason_code}) do
+    maybe_put_finish_reason(output, %{finish_reason: finish_reason_from_code(finish_reason_code)})
+  end
+
+  defp maybe_put_serving_finish_reason(output, _metadata), do: output
+
+  defp finish_reason_code(:stop), do: 0
+  defp finish_reason_code(:length), do: 1
+  defp finish_reason_code(_other), do: 1
+
+  defp finish_reason_from_code(%Nx.Tensor{} = code) do
+    code
+    |> Nx.to_flat_list()
+    |> hd()
+    |> finish_reason_from_code()
+  end
+
+  defp finish_reason_from_code(0), do: :stop
+  defp finish_reason_from_code(_), do: :length
 
   @doc """
   Convenience: load `%State{}` from an MLX-4bit checkpoint directory and build a serving.
@@ -397,7 +458,7 @@ defmodule EMLXAxon.TextGeneration do
 
   defp normalize_input(inputs) when is_list(inputs) do
     raise ArgumentError,
-          "native Qwen3 text generation currently supports one input at a time, got a list"
+          "native text generation currently supports one input at a time, got a list"
   end
 
   defp normalize_input(input) do
@@ -419,6 +480,20 @@ defmodule EMLXAxon.TextGeneration do
           "expected :max_new_tokens to be a positive integer, got: #{inspect(max_new)}"
   end
 
+  defp max_len!(opts, default) do
+    opts
+    |> Keyword.get(:max_len, default)
+    |> validate_max_len!()
+  end
+
+  defp validate_max_len!(max_len) when is_integer(max_len) and max_len > 0,
+    do: max_len
+
+  defp validate_max_len!(max_len) do
+    raise ArgumentError,
+          "expected :max_len to be a positive integer, got: #{inspect(max_len)}"
+  end
+
   defp ensure_single_batch!(input_ids) do
     case Nx.shape(input_ids) do
       {1, _seq_len} ->
@@ -426,7 +501,7 @@ defmodule EMLXAxon.TextGeneration do
 
       {batch_size, _seq_len} ->
         raise ArgumentError,
-              "native Qwen3 text generation currently supports batch size 1, got batch size #{batch_size}"
+              "native text generation currently supports batch size 1, got batch size #{batch_size}"
 
       shape ->
         raise ArgumentError,
@@ -464,7 +539,7 @@ defmodule EMLXAxon.TextGeneration do
          :per_token,
          opts
        ) do
-    Generate.generate(input_ids, state,
+    generate_module(state).generate(input_ids, state,
       kv_cache: kv_cache,
       max_new_tokens: Keyword.fetch!(opts, :max_new),
       max_len: Keyword.fetch!(opts, :max_len),
@@ -492,7 +567,7 @@ defmodule EMLXAxon.TextGeneration do
          opts
        )
        when is_integer(chunk_size) and chunk_size > 0 do
-    Generate.generate(input_ids, state,
+    generate_module(state).generate(input_ids, state,
       kv_cache: kv_cache,
       max_new_tokens: Keyword.fetch!(opts, :max_new),
       max_len: Keyword.fetch!(opts, :max_len),

--- a/emlx_axon/mix.exs
+++ b/emlx_axon/mix.exs
@@ -15,8 +15,8 @@ defmodule EMLXAxon.MixProject do
       aliases: aliases(),
       description: "Axon model rewrites to swap supported nodes for EMLX.Fast Metal shaders",
       package: package(),
-      # elixir_make — builds the standalone qwen3 compute plugin
-      # (c_src/qwen3_plugin.cpp), `dlopen`'d at runtime by emlx's
+      # elixir_make — builds the standalone model compute plugins
+      # (c_src/*_plugin.cpp), `dlopen`'d at runtime by emlx's
       # `EMLX.NIF.load_plugin/2` (see lib/emlx_axon/application.ex). A
       # function ref so `Application.app_dir(:emlx, ...)` (needs the
       # :emlx dep already compiled) isn't called while this project/0
@@ -28,7 +28,9 @@ defmodule EMLXAxon.MixProject do
         %{
           "MLX_INCLUDE_DIR" => Path.join(emlx_priv_dir, "mlx/include"),
           "MLX_LIB_DIR" => Path.join(emlx_priv_dir, "mlx/lib"),
-          "QWEN3_ABI_INCLUDE_DIR" => Path.join(Mix.Project.deps_paths()[:emlx], "c_src/emlx_fast")
+          "QWEN3_ABI_INCLUDE_DIR" =>
+            Path.join(Mix.Project.deps_paths()[:emlx], "c_src/emlx_fast"),
+          "LLAMA_ABI_INCLUDE_DIR" => Path.join(Mix.Project.deps_paths()[:emlx], "c_src/emlx_fast")
         }
       end,
       compilers: [:elixir_make] ++ Mix.compilers()
@@ -42,12 +44,19 @@ defmodule EMLXAxon.MixProject do
   defp deps do
     [
       {:elixir_make, "~> 0.6"},
-      {:emlx, "~> 0.4.0"},
-      # {:emlx, path: "../emlx"},
+      emlx_dep(),
       {:axon, "~> 0.7"},
       {:bumblebee, "~> 0.7"},
       {:ex_doc, "~> 0.34", only: :docs}
     ]
+  end
+
+  defp emlx_dep do
+    if System.get_env("EMLX_AXON_LOCAL_EMLX") == "true" do
+      {:emlx, path: "../emlx", override: true}
+    else
+      {:emlx, "~> 0.4.0"}
+    end
   end
 
   def cli do

--- a/emlx_axon/test/emlx/llama_dense_loader_test.exs
+++ b/emlx_axon/test/emlx/llama_dense_loader_test.exs
@@ -1,0 +1,469 @@
+defmodule EMLXAxon.LlamaDenseLoaderTest do
+  use ExUnit.Case, async: true
+
+  alias EMLXAxon.Llama.{DenseLoader, Generate, Model, Rope}
+
+  test "builds native state from Bumblebee dense Llama params" do
+    params = %Axon.ModelState{data: params()}
+
+    assert {:ok, state} = DenseLoader.from_model_info(%{params: params, spec: spec()})
+
+    assert Nx.shape(state.embed_tokens) == {16, 4}
+    assert Nx.shape(state.lm_head) == {16, 4}
+    assert Nx.shape(state.norm) == {4}
+    assert state.config.hidden_size == 4
+    assert state.config.num_hidden_layers == 1
+
+    [layer] = state.layers
+
+    {_norm1, _norm2, q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj} = layer
+
+    assert Nx.shape(q_proj) == {4, 4}
+    assert Nx.shape(k_proj) == {4, 2}
+    assert Nx.shape(v_proj) == {4, 2}
+    assert Nx.shape(o_proj) == {4, 4}
+    assert Nx.shape(gate_proj) == {4, 8}
+    assert Nx.shape(up_proj) == {4, 8}
+    assert Nx.shape(down_proj) == {8, 4}
+  end
+
+  test "rejects unsupported Bumblebee Llama activation" do
+    params = %Axon.ModelState{data: params()}
+    spec = spec(activation: :gelu)
+
+    assert {:error, message} = DenseLoader.from_model_info(%{params: params, spec: spec})
+    assert message =~ "supports activation :silu only"
+    assert message =~ ":gelu"
+  end
+
+  test "rejects non-keyword model_info options with a clear error" do
+    model_info = %{params: %Axon.ModelState{data: params()}, spec: spec()}
+
+    assert {:error, message} = DenseLoader.from_model_info(model_info, :bad_opts)
+    assert message =~ "expected opts to be a keyword list"
+    assert message =~ ":bad_opts"
+  end
+
+  test "uses token ids from Bumblebee generation config" do
+    model_info = %{params: %Axon.ModelState{data: params()}, spec: spec()}
+
+    assert {:ok, probe_state} = DenseLoader.from_model_info(model_info)
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    {[first_token], _metadata} =
+      Generate.generate(input_ids, probe_state,
+        max_new_tokens: 1,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    generation_config = %Bumblebee.Text.GenerationConfig{
+      eos_token_id: [first_token, 128_009],
+      bos_token_id: 128_000
+    }
+
+    assert {:ok, state} =
+             DenseLoader.from_model_info(model_info, generation_config: generation_config)
+
+    assert state.config.eos_token_id == [first_token, 128_009]
+    assert state.config.bos_token_id == 128_000
+
+    {tokens, metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 5,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    assert tokens == [first_token]
+    assert metadata.finish_reason == :stop
+  end
+
+  test "keeps params already loaded on EMLX GPU" do
+    params = params() |> gpu_params()
+    model_state = %Axon.ModelState{data: params}
+
+    assert {:ok, state} = DenseLoader.from_model_info(%{params: model_state, spec: spec()})
+
+    assert emlx_ref(state.embed_tokens) == emlx_ref(params["embedder.token_embedding"]["kernel"])
+    assert emlx_ref(state.norm) == emlx_ref(params["output_norm"]["weight"])
+  end
+
+  test "builds native state directly from dense safetensors directory" do
+    dir = Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    config_path = Path.join(dir, "config.json")
+    safetensors_path = Path.join(dir, "model.safetensors")
+
+    File.write!(config_path, Jason.encode!(config_json()))
+    Safetensors.write!(safetensors_path, safetensors_params())
+
+    assert {:ok, state} = DenseLoader.from_safetensors_dir(dir, type: :f16)
+
+    assert {:ok, file_state} =
+             DenseLoader.from_safetensors_files(config_path, [safetensors_path], type: :f16)
+
+    assert Nx.shape(state.embed_tokens) == {16, 4}
+    assert Nx.shape(state.lm_head) == {16, 4}
+    assert emlx_ref(state.lm_head) == emlx_ref(state.embed_tokens)
+    assert Nx.shape(file_state.embed_tokens) == {16, 4}
+    assert state.config.eos_token_id == 2
+
+    [layer] = state.layers
+
+    {_norm1, _norm2, q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj} = layer
+
+    assert Nx.shape(q_proj) == {4, 4}
+    assert Nx.shape(k_proj) == {4, 2}
+    assert Nx.shape(v_proj) == {4, 2}
+    assert Nx.shape(o_proj) == {4, 4}
+    assert Nx.shape(gate_proj) == {4, 8}
+    assert Nx.shape(up_proj) == {4, 8}
+    assert Nx.shape(down_proj) == {8, 4}
+    assert match?(%EMLX.Backend{}, q_proj.data)
+
+    assert tensor_values(q_proj) == [
+             0.0,
+             4.0,
+             8.0,
+             12.0,
+             1.0,
+             5.0,
+             9.0,
+             13.0,
+             2.0,
+             6.0,
+             10.0,
+             14.0,
+             3.0,
+             7.0,
+             11.0,
+             15.0
+           ]
+
+    assert tensor_values(k_proj) == [0.0, 4.0, 1.0, 5.0, 2.0, 6.0, 3.0, 7.0]
+  end
+
+  test "dense state loaded from safetensors can run native generation" do
+    dir = Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    config_path = Path.join(dir, "config.json")
+    safetensors_path = Path.join(dir, "model.safetensors")
+
+    File.write!(config_path, Jason.encode!(config_json()))
+    Safetensors.write!(safetensors_path, safetensors_params())
+
+    assert {:ok, state} = DenseLoader.from_safetensors_files(config_path, [safetensors_path])
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    {tokens, metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 2,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    assert length(tokens) == 2
+    assert Enum.all?(tokens, &is_integer/1)
+    assert metadata.finish_reason in [:length, :stop]
+  end
+
+  test "KV cache dtype follows bf16 safetensors state dtype" do
+    dir = Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    config_path = Path.join(dir, "config.json")
+    safetensors_path = Path.join(dir, "model.safetensors")
+
+    File.write!(config_path, Jason.encode!(config_json()))
+    Safetensors.write!(safetensors_path, safetensors_params())
+
+    assert {:ok, state} =
+             DenseLoader.from_safetensors_files(config_path, [safetensors_path], type: :bf16)
+
+    [{k_cache, v_cache}] = Model.init_kv_cache(state, 8)
+    [{k_ref, v_ref}] = Model.init_native_kv_cache(state, 8)
+
+    assert Nx.type(state.embed_tokens) == {:bf, 16}
+    assert Nx.type(k_cache) == {:bf, 16}
+    assert Nx.type(v_cache) == {:bf, 16}
+    assert EMLX.scalar_type(k_ref) == :bfloat16
+    assert EMLX.scalar_type(v_ref) == :bfloat16
+  end
+
+  test "rejects unsupported safetensors cast type" do
+    dir = Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    config_path = Path.join(dir, "config.json")
+    safetensors_path = Path.join(dir, "model.safetensors")
+
+    File.write!(config_path, Jason.encode!(config_json()))
+    Safetensors.write!(safetensors_path, safetensors_params())
+
+    assert {:error, message} =
+             DenseLoader.from_safetensors_files(config_path, [safetensors_path], type: :fp16)
+
+    assert message =~ "expected :type"
+  end
+
+  test "rejects CPU safetensors device for native dense generation" do
+    dir = Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    config_path = Path.join(dir, "config.json")
+    safetensors_path = Path.join(dir, "model.safetensors")
+
+    File.write!(config_path, Jason.encode!(config_json()))
+    Safetensors.write!(safetensors_path, safetensors_params())
+
+    assert {:error, message} =
+             DenseLoader.from_safetensors_files(config_path, [safetensors_path], device: :cpu)
+
+    assert message =~ "supports device: :gpu only"
+  end
+
+  test "rejects unsupported safetensors RoPE scaling config" do
+    dir = Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    config_path = Path.join(dir, "config.json")
+    safetensors_path = Path.join(dir, "model.safetensors")
+
+    config =
+      Map.put(config_json(), "rope_scaling", %{
+        "rope_type" => "linear",
+        "factor" => 2.0
+      })
+
+    File.write!(config_path, Jason.encode!(config))
+    Safetensors.write!(safetensors_path, safetensors_params())
+
+    assert {:error, message} = DenseLoader.from_safetensors_files(config_path, [safetensors_path])
+    assert message =~ "supports nil or llama3 rope scaling"
+  end
+
+  test "rejects unsupported safetensors config features" do
+    for {field, value, expected} <- [
+          {"attention_bias", true, "attention_bias=true"},
+          {"mlp_bias", true, "mlp_bias=true"},
+          {"hidden_act", "gelu", ~s(hidden_act "silu")}
+        ] do
+      dir =
+        Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      config_path = Path.join(dir, "config.json")
+      safetensors_path = Path.join(dir, "model.safetensors")
+
+      config = Map.put(config_json(), field, value)
+
+      File.write!(config_path, Jason.encode!(config))
+      Safetensors.write!(safetensors_path, safetensors_params())
+
+      assert {:error, message} =
+               DenseLoader.from_safetensors_files(config_path, [safetensors_path])
+
+      assert message =~ expected
+    end
+  end
+
+  test "rejects invalid safetensors device for native dense generation" do
+    assert {:error, message} =
+             DenseLoader.from_safetensors_files("missing-config.json", [], device: :tpu)
+
+    assert message =~ "supports device: :gpu only"
+    assert message =~ ":tpu"
+  end
+
+  test "returns an error when a safetensors checkpoint is missing a required key" do
+    dir = Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    config_path = Path.join(dir, "config.json")
+    safetensors_path = Path.join(dir, "model.safetensors")
+
+    tensors = Map.delete(safetensors_params(), "model.layers.0.self_attn.k_proj.weight")
+
+    File.write!(config_path, Jason.encode!(config_json()))
+    Safetensors.write!(safetensors_path, tensors)
+
+    assert {:error, message} = DenseLoader.from_safetensors_files(config_path, [safetensors_path])
+    assert message =~ "model.layers.0.self_attn.k_proj.weight"
+  end
+
+  test "requires lm_head weight when safetensors embeddings are not tied" do
+    dir = Path.join(System.tmp_dir!(), "llama_dense_loader_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    config_path = Path.join(dir, "config.json")
+    safetensors_path = Path.join(dir, "model.safetensors")
+
+    config = Map.put(config_json(), "tie_word_embeddings", false)
+
+    File.write!(config_path, Jason.encode!(config))
+    Safetensors.write!(safetensors_path, safetensors_params())
+
+    assert {:error, message} = DenseLoader.from_safetensors_files(config_path, [safetensors_path])
+    assert message =~ "lm_head.weight"
+  end
+
+  test "precomputes RoPE frequencies in MLX fast rope convention" do
+    freqs =
+      %{
+        head_dim: 8,
+        rope_theta: 10_000.0,
+        rope_scaling: nil
+      }
+      |> Rope.freqs_from_config!()
+      |> tensor_values()
+
+    assert_all_close(freqs, [1.0, 10.0, 100.0, 1000.0], atol: 1.0e-4)
+
+    inverse_freqs = Enum.map(freqs, &Kernel./(1.0, &1))
+    assert_all_close(inverse_freqs, [1.0, 0.1, 0.01, 0.001], atol: 1.0e-6)
+  end
+
+  test "precomputes Llama 3 RoPE scaling frequencies in MLX fast rope convention" do
+    freqs =
+      %{
+        head_dim: 8,
+        rope_theta: 10_000.0,
+        rope_scaling: %{
+          type: :llama3,
+          factor: 8.0,
+          low_frequency_factor: 1.0,
+          high_frequency_factor: 4.0,
+          original_max_positions: 8192
+        }
+      }
+      |> Rope.freqs_from_config!()
+      |> tensor_values()
+
+    inverse_freqs = Enum.map(freqs, &Kernel./(1.0, &1))
+    assert_all_close(inverse_freqs, [1.0, 0.1, 0.01, 0.000213761], atol: 1.0e-6)
+  end
+
+  defp spec(opts \\ []) do
+    defaults = [
+      architecture: :for_causal_language_modeling,
+      vocab_size: 16,
+      hidden_size: 4,
+      intermediate_size: 8,
+      attention_head_size: 2,
+      num_blocks: 1,
+      num_attention_heads: 2,
+      num_key_value_heads: 1,
+      rotary_embedding_base: 10_000,
+      layer_norm_epsilon: 1.0e-6,
+      tie_word_embeddings: true
+    ]
+
+    struct!(Bumblebee.Text.Llama, Keyword.merge(defaults, opts))
+  end
+
+  defp config_json do
+    %{
+      "hidden_size" => 4,
+      "intermediate_size" => 8,
+      "num_attention_heads" => 2,
+      "num_key_value_heads" => 1,
+      "head_dim" => 2,
+      "num_hidden_layers" => 1,
+      "vocab_size" => 16,
+      "rms_norm_eps" => 1.0e-6,
+      "rope_theta" => 10_000,
+      "tie_word_embeddings" => true,
+      "eos_token_id" => 2,
+      "bos_token_id" => 1
+    }
+  end
+
+  defp safetensors_params do
+    %{
+      "model.embed_tokens.weight" => Nx.iota({16, 4}, type: :f16),
+      "model.norm.weight" => f16_ones({4}),
+      "model.layers.0.input_layernorm.weight" => f16_ones({4}),
+      "model.layers.0.post_attention_layernorm.weight" => f16_ones({4}),
+      "model.layers.0.self_attn.q_proj.weight" => Nx.iota({4, 4}, type: :f16),
+      "model.layers.0.self_attn.k_proj.weight" => Nx.iota({2, 4}, type: :f16),
+      "model.layers.0.self_attn.v_proj.weight" => Nx.iota({2, 4}, type: :f16),
+      "model.layers.0.self_attn.o_proj.weight" => Nx.iota({4, 4}, type: :f16),
+      "model.layers.0.mlp.gate_proj.weight" => Nx.iota({8, 4}, type: :f16),
+      "model.layers.0.mlp.up_proj.weight" => Nx.iota({8, 4}, type: :f16),
+      "model.layers.0.mlp.down_proj.weight" => Nx.iota({4, 8}, type: :f16)
+    }
+  end
+
+  defp f16_ones(shape), do: Nx.broadcast(Nx.tensor(1.0, type: :f16), shape)
+
+  defp params do
+    %{}
+    |> put("embedder.token_embedding", "kernel", Nx.iota({16, 4}, type: :f32))
+    |> put("language_modeling_head.output", "kernel", Nx.iota({16, 4}, type: :f32))
+    |> put("output_norm", "weight", Nx.broadcast(1.0, {4}))
+    |> put("decoder.blocks.0.self_attention_norm", "weight", Nx.broadcast(1.0, {4}))
+    |> put("decoder.blocks.0.output_norm", "weight", Nx.broadcast(1.0, {4}))
+    |> put("decoder.blocks.0.self_attention.query", "kernel", Nx.iota({4, 4}, type: :f32))
+    |> put("decoder.blocks.0.self_attention.key", "kernel", Nx.iota({4, 2}, type: :f32))
+    |> put("decoder.blocks.0.self_attention.value", "kernel", Nx.iota({4, 2}, type: :f32))
+    |> put("decoder.blocks.0.self_attention.output", "kernel", Nx.iota({4, 4}, type: :f32))
+    |> put("decoder.blocks.0.ffn.gate", "kernel", Nx.iota({4, 8}, type: :f32))
+    |> put("decoder.blocks.0.ffn.intermediate", "kernel", Nx.iota({4, 8}, type: :f32))
+    |> put("decoder.blocks.0.ffn.output", "kernel", Nx.iota({8, 4}, type: :f32))
+  end
+
+  defp put(params, scope, name, tensor) do
+    Map.update(params, scope, %{name => tensor}, &Map.put(&1, name, tensor))
+  end
+
+  defp gpu_params(params) do
+    Map.new(params, fn {scope, values} ->
+      values =
+        Map.new(values, fn {name, tensor} ->
+          {name, Nx.backend_transfer(tensor, {EMLX.Backend, device: :gpu})}
+        end)
+
+      {scope, values}
+    end)
+  end
+
+  defp emlx_ref(%Nx.Tensor{data: %EMLX.Backend{ref: ref}}), do: ref
+
+  defp tensor_values(tensor) do
+    tensor
+    |> Nx.backend_transfer(Nx.BinaryBackend)
+    |> Nx.to_flat_list()
+  end
+
+  defp assert_all_close(left, right, opts) do
+    atol = Keyword.fetch!(opts, :atol)
+
+    assert Enum.zip(left, right)
+           |> Enum.all?(fn {left, right} -> abs(left - right) <= atol end)
+  end
+end

--- a/emlx_axon/test/emlx/llama_generate_test.exs
+++ b/emlx_axon/test/emlx/llama_generate_test.exs
@@ -1,0 +1,914 @@
+defmodule EMLXAxon.LlamaGenerateTest do
+  use ExUnit.Case, async: true
+
+  alias EMLXAxon.Llama.{DenseLoader, Generate, Model, Sampler}
+
+  test "greedy decode token id forward matches tensor token forward" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    kv_cache_for_tensor = Model.init_kv_cache(state, 8)
+    kv_cache_for_id = Model.init_kv_cache(state, 8)
+    input_ids = Nx.tensor([[1]], type: :s64, backend: {EMLX.Backend, device: :gpu})
+
+    {token, _kv_cache} = Model.forward_greedy(input_ids, kv_cache_for_tensor, 0, state)
+    {token_id, _kv_cache} = Model.forward_greedy_decode_token_id(1, kv_cache_for_id, 0, state)
+
+    assert token_id == Nx.to_number(token)
+  end
+
+  test "native KV cache uses raw refs for greedy dense generation" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    [{k_cache, v_cache}] = Model.init_native_kv_cache(state, 8)
+    assert {:gpu, k_ref} = k_cache
+    assert {:gpu, v_ref} = v_cache
+    assert is_reference(k_ref)
+    assert is_reference(v_ref)
+
+    {token_id, _kv_cache} =
+      Model.forward_greedy_decode_token_id(1, [{k_cache, v_cache}], 0, state)
+
+    assert is_integer(token_id)
+  end
+
+  test "KV cache dtype follows dense state dtype from Bumblebee params" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params(:f32)},
+        spec: spec()
+      })
+
+    [{k_cache, v_cache}] = Model.init_kv_cache(state, 8)
+    [{k_ref, v_ref}] = Model.init_native_kv_cache(state, 8)
+
+    assert Nx.type(state.embed_tokens) == {:f, 32}
+    assert Nx.type(k_cache) == {:f, 32}
+    assert Nx.type(v_cache) == {:f, 32}
+    assert EMLX.scalar_type(k_ref) == :float32
+    assert EMLX.scalar_type(v_ref) == :float32
+  end
+
+  test "dense transformer layer accepts DenseLoader projection layout" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    [layer] = state.layers
+
+    hidden =
+      Nx.broadcast(Nx.tensor(0.1, type: :f16), {1, 1, state.config.hidden_size})
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    [{k_cache, v_cache}] = Model.init_kv_cache(state, 8)
+
+    assert {hidden_out, k_cache_updated, v_cache_updated} =
+             Model.transformer_layer(hidden, k_cache, v_cache, 0, layer, state.config)
+
+    assert Nx.shape(hidden_out) == {1, 1, state.config.hidden_size}
+    assert Nx.shape(k_cache_updated) == Nx.shape(k_cache)
+    assert Nx.shape(v_cache_updated) == Nx.shape(v_cache)
+  end
+
+  test "end host sync returns the same greedy token ids as sync after each token" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    {per_token, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 3,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    {end_sync, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 3,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :end,
+        profile_timing: false
+      )
+
+    assert end_sync == per_token
+  end
+
+  test "native greedy wrappers match tensor-step greedy generation" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    tensor_step_state = tensor_step_state(state)
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    for host_sync <- [:per_token, :end, {:chunk, 2}] do
+      {native_tokens, native_metadata} =
+        Generate.generate(input_ids, state,
+          max_new_tokens: 5,
+          max_len: 8,
+          sampler: :greedy,
+          host_sync: host_sync,
+          profile_timing: false
+        )
+
+      {tensor_step_tokens, tensor_step_metadata} =
+        Generate.generate(input_ids, tensor_step_state,
+          max_new_tokens: 5,
+          max_len: 8,
+          sampler: :greedy,
+          host_sync: host_sync,
+          profile_timing: false
+        )
+
+      assert native_tokens == tensor_step_tokens
+      assert native_metadata.finish_reason == tensor_step_metadata.finish_reason
+    end
+  end
+
+  test "native greedy generation is stable across repeated runs" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    {expected_tokens, expected_metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 4,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: {:chunk, 2},
+        profile_timing: false
+      )
+
+    for _run <- 1..25 do
+      {tokens, metadata} =
+        Generate.generate(input_ids, state,
+          max_new_tokens: 4,
+          max_len: 8,
+          sampler: :greedy,
+          host_sync: {:chunk, 2},
+          profile_timing: false
+        )
+
+      assert tokens == expected_tokens
+      assert metadata.finish_reason == expected_metadata.finish_reason
+    end
+  end
+
+  test "generation stops when any token in eos_token_id list is emitted" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    {[first_token], _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 1,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    state = %{state | config: %{state.config | eos_token_id: [first_token, 2]}}
+
+    {tokens, metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 5,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    assert tokens == [first_token]
+    assert metadata.finish_reason == :stop
+  end
+
+  test "end host sync falls back to sync after each token when streaming callback is configured" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    parent = self()
+
+    {tokens, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 2,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :end,
+        profile_timing: false,
+        token_callback: fn token_id -> send(parent, {:token, token_id}) end
+      )
+
+    assert_receive {:token, first_token}
+    assert first_token == hd(tokens)
+  end
+
+  test "profile timing reports microsecond-resolution millisecond values" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    for host_sync <- [:per_token, :end, {:chunk, 2}] do
+      {_tokens, %{timing: timing}} =
+        Generate.generate(input_ids, state,
+          max_new_tokens: 3,
+          max_len: 8,
+          sampler: :greedy,
+          host_sync: host_sync,
+          profile_timing: true
+        )
+
+      assert is_float(timing.prefill_ms)
+      assert is_float(timing.total_ms)
+      assert length(timing.per_token_ms) == 2
+      assert Enum.all?(timing.per_token_ms, &is_float/1)
+    end
+  end
+
+  test "chunked host sync returns the same greedy token ids as sync after each token" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    {per_token, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 5,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    {chunked, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 5,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: {:chunk, 2},
+        profile_timing: false
+      )
+
+    assert chunked == per_token
+  end
+
+  test "generation rejects batched input_ids with end host sync" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2], [3, 4]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise ArgumentError, ~r/batch size 1, got batch size 2/, fn ->
+      Generate.generate(input_ids, state,
+        max_new_tokens: 2,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :end,
+        profile_timing: false
+      )
+    end
+  end
+
+  test "generation rejects batched input_ids with chunked host sync" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2], [3, 4]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise ArgumentError, ~r/batch size 1, got batch size 2/, fn ->
+      Generate.generate(input_ids, state,
+        max_new_tokens: 2,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: {:chunk, 2},
+        profile_timing: false
+      )
+    end
+  end
+
+  test "chunked host sync emits host token chunks" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    parent = self()
+
+    {tokens, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 5,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: {:chunk, 2},
+        profile_timing: false,
+        chunk_callback: fn token_ids -> send(parent, {:chunk, token_ids}) end
+      )
+
+    assert_receive {:chunk, first_chunk}
+    assert_receive {:chunk, second_chunk}
+    assert_receive {:chunk, final_chunk}
+    refute_receive {:chunk, _extra}
+
+    assert [first_chunk, second_chunk, final_chunk] |> List.flatten() == tokens
+    assert length(first_chunk) == 2
+    assert length(second_chunk) == 2
+    assert length(final_chunk) == 1
+  end
+
+  test "chunked host sync can emit the first token immediately" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    {per_token, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 5,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    parent = self()
+
+    {chunked, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 5,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: {:chunk, 2},
+        profile_timing: false,
+        chunk_callback_first_token: true,
+        chunk_callback: fn token_ids -> send(parent, {:chunk, token_ids}) end
+      )
+
+    assert_receive {:chunk, first_chunk}
+    assert_receive {:chunk, second_chunk}
+    assert_receive {:chunk, third_chunk}
+    refute_receive {:chunk, _extra}
+
+    assert length(first_chunk) == 1
+    assert first_chunk == [hd(per_token)]
+    assert [first_chunk, second_chunk, third_chunk] |> List.flatten() == chunked
+    assert chunked == per_token
+  end
+
+  test "chunked host sync falls back to sync after each token when streaming callback is configured" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    parent = self()
+
+    {tokens, _metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 2,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: {:chunk, 2},
+        profile_timing: false,
+        token_callback: fn token_id -> send(parent, {:token, token_id}) end
+      )
+
+    assert_receive {:token, first_token}
+    assert first_token == hd(tokens)
+  end
+
+  test "chunked host sync requires a positive integer chunk size" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise ArgumentError, ~r/positive integer/, fn ->
+      Generate.generate(input_ids, state,
+        max_new_tokens: 2,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: {:chunk, 0},
+        profile_timing: false
+      )
+    end
+  end
+
+  test "generation caps max_new_tokens to KV cache capacity" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    {tokens, metadata} =
+      Generate.generate(input_ids, state,
+        max_new_tokens: 5,
+        max_len: 3,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    assert length(tokens) == 2
+    assert metadata.finish_reason == :length
+  end
+
+  test "generation caps max_new_tokens to provided KV cache capacity" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    kv_cache = Model.init_kv_cache(state, 3)
+
+    {tokens, metadata} =
+      Generate.generate(input_ids, state,
+        kv_cache: kv_cache,
+        max_new_tokens: 5,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+
+    assert length(tokens) == 2
+    assert metadata.finish_reason == :length
+  end
+
+  test "generation rejects inputs longer than KV cache capacity" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2, 3]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise ArgumentError, ~r/input length/, fn ->
+      Generate.generate(input_ids, state,
+        max_new_tokens: 1,
+        max_len: 2,
+        sampler: :greedy,
+        host_sync: :per_token,
+        profile_timing: false
+      )
+    end
+  end
+
+  test "generation rejects invalid max_len before cache allocation" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    for max_len <- [0, -1, 1.5, "8"] do
+      assert_raise ArgumentError, ~r/expected :max_len to be a positive integer/, fn ->
+        Generate.generate(input_ids, state,
+          max_new_tokens: 1,
+          max_len: max_len,
+          sampler: :greedy,
+          host_sync: :per_token,
+          profile_timing: false
+        )
+      end
+    end
+  end
+
+  test "native greedy forward rejects invalid layer tuples" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    [layer] = state.layers
+    bad_state = %{state | layers: [Tuple.delete_at(layer, 8)]}
+    kv_cache = Model.init_native_kv_cache(bad_state, 8)
+
+    input_ids =
+      Nx.tensor([[1]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise FunctionClauseError, fn ->
+      Model.forward_greedy(input_ids, kv_cache, 0, bad_state)
+    end
+  end
+
+  test "native greedy forward rejects mismatched layer and cache counts" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise EMLX.NIFError, ~r/layers and kv_cache length mismatch/, fn ->
+      Model.forward_greedy(input_ids, [], 0, state)
+    end
+  end
+
+  test "native greedy forward rejects projection widths not divisible by head dim" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    [layer] = state.layers
+    bad_q_proj = Nx.iota({4, 5}, type: :f16)
+    bad_state = %{state | layers: [put_elem(layer, 2, bad_q_proj)]}
+    kv_cache = Model.init_native_kv_cache(bad_state, 8)
+
+    input_ids =
+      Nx.tensor([[1]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise EMLX.NIFError, ~r/q_proj output width must be divisible by head_dim/, fn ->
+      Model.forward_greedy(input_ids, kv_cache, 0, bad_state)
+    end
+  end
+
+  test "native greedy forward rejects deallocated layer tensor refs" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    [layer] = state.layers
+    q_proj = elem(layer, 2)
+    kv_cache = Model.init_native_kv_cache(state, 8)
+
+    input_ids =
+      Nx.tensor([[1]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    Nx.backend_deallocate(q_proj)
+
+    assert_raise EMLX.NIFError, ~r/Tensor has been deallocated/, fn ->
+      Model.forward_greedy(input_ids, kv_cache, 0, state)
+    end
+  end
+
+  test "native greedy forward rejects deallocated kv cache refs" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    [{k_cache, _v_cache}] = kv_cache = Model.init_native_kv_cache(state, 8)
+
+    input_ids =
+      Nx.tensor([[1]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    EMLX.deallocate(k_cache)
+
+    assert_raise EMLX.NIFError, ~r/Tensor has been deallocated/, fn ->
+      Model.forward_greedy(input_ids, kv_cache, 0, state)
+    end
+  end
+
+  test "native greedy forward rejects deallocated final norm refs" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    kv_cache = Model.init_native_kv_cache(state, 8)
+
+    input_ids =
+      Nx.tensor([[1]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    Nx.backend_deallocate(state.norm)
+
+    assert_raise EMLX.NIFError, ~r/Tensor has been deallocated/, fn ->
+      Model.forward_greedy(input_ids, kv_cache, 0, state)
+    end
+  end
+
+  test "native greedy forward rejects cache capacity overflow" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    kv_cache = Model.init_native_kv_cache(state, 2)
+
+    assert_raise EMLX.NIFError, ~r/KV cache capacity 2 is smaller than required length 3/, fn ->
+      Model.forward_greedy(input_ids, kv_cache, 2, state)
+    end
+  end
+
+  test "native token id return path rejects batched inputs" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1], [2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise ArgumentError,
+                 ~r/llama_forward_greedy_ids_token_id requires batch size 1, got batch size 2/,
+                 fn ->
+                   EMLX.Native.Llama.forward_greedy_ids_token_id(
+                     EMLX.Backend.from_nx(input_ids),
+                     EMLX.Backend.from_nx(state.embed_tokens),
+                     [],
+                     [],
+                     EMLX.Backend.from_nx(state.norm),
+                     EMLX.Backend.from_nx(state.lm_head),
+                     0,
+                     1.0 / :math.sqrt(state.config.head_dim),
+                     state.config.head_dim,
+                     EMLX.Backend.from_nx(state.rope_freqs),
+                     state.config.rms_norm_eps
+                   )
+                 end
+  end
+
+  test "native chunk token id return path rejects batched inputs" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1], [2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    embed_ref = EMLX.Backend.from_nx(state.embed_tokens)
+
+    assert_raise ArgumentError, ~r/llama_forward_greedy_ids_chunk requires batch size 1/, fn ->
+      EMLX.Native.Llama.forward_greedy_ids_chunk(
+        EMLX.Backend.from_nx(input_ids),
+        embed_ref,
+        [],
+        [],
+        EMLX.Backend.from_nx(state.norm),
+        EMLX.Backend.from_nx(state.lm_head),
+        0,
+        1,
+        1.0 / :math.sqrt(state.config.head_dim),
+        state.config.head_dim,
+        EMLX.Backend.from_nx(state.rope_freqs),
+        state.config.rms_norm_eps
+      )
+    end
+  end
+
+  test "generation rejects unsupported host sync modes" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    assert_raise ArgumentError, ~r/expected :host_sync/, fn ->
+      Generate.generate(input_ids, state,
+        max_new_tokens: 2,
+        max_len: 8,
+        sampler: :greedy,
+        host_sync: :sometimes,
+        profile_timing: false
+      )
+    end
+  end
+
+  test "generation rejects zero, negative, string, or decimal max_new_tokens" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    for max_new_tokens <- [0, -1, 1.5, "1"] do
+      assert_raise ArgumentError, ~r/expected :max_new_tokens to be a positive integer/, fn ->
+        Generate.generate(input_ids, state,
+          max_new_tokens: max_new_tokens,
+          max_len: 8,
+          sampler: :greedy,
+          profile_timing: false
+        )
+      end
+    end
+  end
+
+  test "generation rejects invalid sampler options before decode" do
+    {:ok, state} =
+      DenseLoader.from_model_info(%{
+        params: %Axon.ModelState{data: params()},
+        spec: spec()
+      })
+
+    input_ids =
+      Nx.tensor([[1, 2]], type: :s64)
+      |> Nx.backend_transfer({EMLX.Backend, device: :gpu})
+
+    cases = [
+      {[sampler: :sometimes], ~r/expected :sampler/},
+      {[sampler: :top_p_cpu, temperature: 0.0], ~r/expected :temperature/},
+      {[sampler: :top_p_cpu, temperature: -1.0], ~r/expected :temperature/},
+      {[sampler: :top_p_cpu, temperature: :invalid], ~r/expected :temperature/},
+      {[sampler: :top_p_cpu, top_p: 0.0], ~r/expected :top_p/},
+      {[sampler: :top_p_cpu, top_p: 1.5], ~r/expected :top_p/},
+      {[sampler: :top_p_cpu, top_p: :invalid], ~r/expected :top_p/},
+      {[sampler: :top_p_gpu, temperature: 0.0], ~r/expected :temperature/}
+    ]
+
+    for {opts, message} <- cases do
+      assert_raise ArgumentError, message, fn ->
+        Generate.generate(
+          input_ids,
+          state,
+          Keyword.merge(
+            [
+              max_new_tokens: 1,
+              max_len: 8,
+              profile_timing: false
+            ],
+            opts
+          )
+        )
+      end
+    end
+  end
+
+  test "samplers reject invalid temperature and top_p values" do
+    logits = Nx.tensor([[10.0, 1.0, 0.0]], type: :f32)
+
+    assert_raise ArgumentError, ~r/expected temperature/, fn ->
+      Sampler.top_p_cpu(logits, 0.0, 0.9)
+    end
+
+    assert_raise ArgumentError, ~r/expected top_p/, fn ->
+      Sampler.top_p_cpu(logits, 1.0, 0.0)
+    end
+
+    assert_raise ArgumentError, ~r/expected temperature/, fn ->
+      Sampler.top_p_gpu(logits, Nx.Random.key(42), temperature: -1.0)
+    end
+  end
+
+  defp spec do
+    %Bumblebee.Text.Llama{
+      architecture: :for_causal_language_modeling,
+      vocab_size: 16,
+      hidden_size: 4,
+      intermediate_size: 8,
+      attention_head_size: 2,
+      num_blocks: 1,
+      num_attention_heads: 2,
+      num_key_value_heads: 1,
+      rotary_embedding_base: 10_000,
+      layer_norm_epsilon: 1.0e-6,
+      tie_word_embeddings: true
+    }
+  end
+
+  defp params(type \\ :f16) do
+    %{}
+    |> put("embedder.token_embedding", "kernel", Nx.iota({16, 4}, type: type))
+    |> put("language_modeling_head.output", "kernel", Nx.iota({16, 4}, type: type))
+    |> put("output_norm", "weight", ones({4}, type))
+    |> put("decoder.blocks.0.self_attention_norm", "weight", ones({4}, type))
+    |> put("decoder.blocks.0.output_norm", "weight", ones({4}, type))
+    |> put("decoder.blocks.0.self_attention.query", "kernel", Nx.iota({4, 4}, type: type))
+    |> put("decoder.blocks.0.self_attention.key", "kernel", Nx.iota({4, 2}, type: type))
+    |> put("decoder.blocks.0.self_attention.value", "kernel", Nx.iota({4, 2}, type: type))
+    |> put("decoder.blocks.0.self_attention.output", "kernel", Nx.iota({4, 4}, type: type))
+    |> put("decoder.blocks.0.ffn.gate", "kernel", Nx.iota({4, 8}, type: type))
+    |> put("decoder.blocks.0.ffn.intermediate", "kernel", Nx.iota({4, 8}, type: type))
+    |> put("decoder.blocks.0.ffn.output", "kernel", Nx.iota({8, 4}, type: type))
+  end
+
+  defp ones(shape, type), do: Nx.broadcast(Nx.tensor(1.0, type: type), shape)
+
+  defp tensor_step_state(state), do: %{state | config: %{state.config | dense_layers?: false}}
+
+  defp put(params, scope, name, tensor) do
+    Map.update(params, scope, %{name => tensor}, &Map.put(&1, name, tensor))
+  end
+end

--- a/emlx_axon/test/emlx/llama_native_test.exs
+++ b/emlx_axon/test/emlx/llama_native_test.exs
@@ -1,0 +1,454 @@
+defmodule EMLXAxon.LlamaNativeTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :metal
+
+  @backend {EMLX.Backend, device: :gpu}
+
+  test "llama_layer matches Nx reference for one token" do
+    hidden = gpu_tensor([[[0.2, -0.4]]], :f32)
+    norm1 = gpu_tensor([1.0, 0.5], :f32)
+    norm2 = gpu_tensor([0.75, 1.25], :f32)
+    q_proj = gpu_tensor([[0.1, -0.2], [0.3, 0.4]], :f32)
+    k_proj = gpu_tensor([[0.2, 0.1], [-0.3, 0.5]], :f32)
+    v_proj = gpu_tensor([[0.6, -0.1], [0.2, 0.3]], :f32)
+    o_proj = gpu_tensor([[0.4, -0.2], [0.1, 0.5]], :f32)
+    gate_proj = gpu_tensor([[0.2, -0.1, 0.3], [0.4, 0.5, -0.2]], :f32)
+    up_proj = gpu_tensor([[0.1, 0.6, -0.3], [-0.4, 0.2, 0.7]], :f32)
+    down_proj = gpu_tensor([[0.3, -0.2], [0.5, 0.1], [-0.4, 0.6]], :f32)
+    k_cache = EMLX.full(0.0, {1, 1, 4, 2}, :float32, :gpu)
+    v_cache = EMLX.full(0.0, {1, 1, 4, 2}, :float32, :gpu)
+    rope_freqs = gpu_tensor([1.0], :f32)
+
+    {out, _k_updated, _v_updated} =
+      EMLX.Native.Llama.layer(
+        EMLX.Backend.from_nx(hidden),
+        EMLX.Backend.from_nx(norm1),
+        EMLX.Backend.from_nx(q_proj),
+        EMLX.Backend.from_nx(k_proj),
+        EMLX.Backend.from_nx(v_proj),
+        EMLX.Backend.from_nx(o_proj),
+        k_cache,
+        v_cache,
+        EMLX.Backend.from_nx(norm2),
+        EMLX.Backend.from_nx(gate_proj),
+        EMLX.Backend.from_nx(up_proj),
+        EMLX.Backend.from_nx(down_proj),
+        0,
+        1.0 / :math.sqrt(2),
+        2,
+        EMLX.Backend.from_nx(rope_freqs),
+        1.0e-5
+      )
+
+    expected =
+      llama_layer_reference(
+        hidden,
+        norm1,
+        q_proj,
+        k_proj,
+        v_proj,
+        o_proj,
+        norm2,
+        gate_proj,
+        up_proj,
+        down_proj,
+        1.0e-5
+      )
+
+    assert_all_close(to_binary(out), expected, atol: 1.0e-4)
+  end
+
+  test "llama_layer matches Nx reference for GQA prefill with nonzero offset" do
+    {hidden, norm1, norm2, q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj, k_cache,
+     v_cache, rope_freqs} =
+      Nx.with_default_backend(Nx.BinaryBackend, fn ->
+        {
+          Nx.iota({1, 2, 4}, type: :f32) |> Nx.add(1) |> Nx.divide(10),
+          Nx.tensor([1.0, 0.5, 1.5, 0.75], type: :f32),
+          Nx.tensor([0.75, 1.25, 0.5, 1.0], type: :f32),
+          Nx.iota({4, 8}, type: :f32) |> Nx.add(1) |> Nx.divide(100),
+          Nx.iota({4, 4}, type: :f32) |> Nx.add(11) |> Nx.divide(110),
+          Nx.iota({4, 4}, type: :f32) |> Nx.add(17) |> Nx.divide(120),
+          Nx.iota({8, 4}, type: :f32) |> Nx.add(23) |> Nx.divide(130),
+          Nx.iota({4, 6}, type: :f32) |> Nx.add(29) |> Nx.divide(140),
+          Nx.iota({4, 6}, type: :f32) |> Nx.add(31) |> Nx.divide(150),
+          Nx.iota({6, 4}, type: :f32) |> Nx.add(37) |> Nx.divide(160),
+          Nx.iota({1, 1, 5, 4}, type: :f32) |> Nx.divide(1_000),
+          Nx.iota({1, 1, 5, 4}, type: :f32) |> Nx.add(50) |> Nx.divide(1_000),
+          Nx.tensor([1.0, 0.25], type: :f32)
+        }
+      end)
+
+    offset = 1
+    head_dim = 4
+    scale = 1.0 / :math.sqrt(head_dim)
+    eps = 1.0e-5
+
+    {out, k_updated, v_updated} =
+      EMLX.Native.Llama.layer(
+        EMLX.Backend.from_nx(gpu_tensor(hidden)),
+        EMLX.Backend.from_nx(gpu_tensor(norm1)),
+        EMLX.Backend.from_nx(gpu_tensor(q_proj)),
+        EMLX.Backend.from_nx(gpu_tensor(k_proj)),
+        EMLX.Backend.from_nx(gpu_tensor(v_proj)),
+        EMLX.Backend.from_nx(gpu_tensor(o_proj)),
+        EMLX.Backend.from_nx(gpu_tensor(k_cache)),
+        EMLX.Backend.from_nx(gpu_tensor(v_cache)),
+        EMLX.Backend.from_nx(gpu_tensor(norm2)),
+        EMLX.Backend.from_nx(gpu_tensor(gate_proj)),
+        EMLX.Backend.from_nx(gpu_tensor(up_proj)),
+        EMLX.Backend.from_nx(gpu_tensor(down_proj)),
+        offset,
+        scale,
+        head_dim,
+        EMLX.Backend.from_nx(gpu_tensor(rope_freqs)),
+        eps
+      )
+
+    {expected, expected_k, expected_v} =
+      llama_layer_reference(
+        hidden,
+        norm1,
+        q_proj,
+        k_proj,
+        v_proj,
+        o_proj,
+        k_cache,
+        v_cache,
+        norm2,
+        gate_proj,
+        up_proj,
+        down_proj,
+        offset,
+        scale,
+        head_dim,
+        rope_freqs,
+        eps
+      )
+
+    assert_all_close(to_binary(out), expected, atol: 5.0e-4)
+    assert_all_close(to_binary(k_updated), expected_k, atol: 1.0e-4)
+    assert_all_close(to_binary(v_updated), expected_v, atol: 1.0e-4)
+  end
+
+  test "llama_final_greedy matches Nx reference on last hidden position" do
+    hidden =
+      gpu_tensor(
+        [
+          [
+            [0.2, -0.1, 0.4, 0.3],
+            [-0.5, 0.6, 0.1, 0.7]
+          ],
+          [
+            [0.8, -0.2, 0.5, -0.4],
+            [0.3, 0.9, -0.6, 0.2]
+          ]
+        ],
+        :f32
+      )
+
+    norm = gpu_tensor([1.0, 0.5, 1.5, 0.75], :f32)
+
+    lm_head =
+      gpu_tensor(
+        [
+          [0.2, -0.1, 0.4, 0.3],
+          [-0.5, 0.6, 0.1, 0.7],
+          [0.8, -0.2, 0.5, -0.4],
+          [0.3, 0.9, -0.6, 0.2],
+          [-0.7, 0.4, 0.2, 0.5]
+        ],
+        :f32
+      )
+
+    out =
+      hidden
+      |> EMLX.Backend.from_nx()
+      |> EMLX.Native.Llama.final_greedy(
+        EMLX.Backend.from_nx(norm),
+        EMLX.Backend.from_nx(lm_head),
+        1.0e-5
+      )
+      |> EMLX.Backend.to_nx()
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    expected = llama_final_greedy_reference(hidden, norm, lm_head, 1.0e-5)
+
+    assert Nx.to_flat_list(out) == Nx.to_flat_list(expected)
+  end
+
+  defp llama_mlp_reference(hidden, norm, gate_proj, up_proj, down_proj, eps) do
+    hidden = Nx.backend_transfer(hidden, Nx.BinaryBackend)
+    norm = Nx.backend_transfer(norm, Nx.BinaryBackend)
+    gate_proj = Nx.backend_transfer(gate_proj, Nx.BinaryBackend)
+    up_proj = Nx.backend_transfer(up_proj, Nx.BinaryBackend)
+    down_proj = Nx.backend_transfer(down_proj, Nx.BinaryBackend)
+
+    variance = hidden |> Nx.pow(2) |> Nx.mean(axes: [-1], keep_axes: true)
+
+    xn =
+      hidden
+      |> Nx.multiply(Nx.rsqrt(Nx.add(variance, eps)))
+      |> Nx.multiply(norm)
+
+    gate = Nx.dot(xn, [2], gate_proj, [0])
+    up = Nx.dot(xn, [2], up_proj, [0])
+
+    mlp =
+      gate
+      |> Nx.multiply(Nx.sigmoid(gate))
+      |> Nx.multiply(up)
+
+    Nx.add(hidden, Nx.dot(mlp, [2], down_proj, [0]))
+  end
+
+  defp llama_kv_cache_attention_reference(
+         q,
+         new_k,
+         new_v,
+         k_cache,
+         v_cache,
+         offset,
+         scale,
+         head_dim,
+         rope_freqs
+       ) do
+    {batch, seq_len, q_heads, _head_dim} = Nx.shape(q)
+    {_batch, _seq_len, kv_heads, _head_dim} = Nx.shape(new_k)
+
+    q_bn =
+      q
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> llama_rope_reference(head_dim, offset, rope_freqs)
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    k_bn =
+      new_k
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> llama_rope_reference(head_dim, offset, rope_freqs)
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    v_bn = new_v |> Nx.transpose(axes: [0, 2, 1, 3]) |> Nx.backend_transfer(Nx.BinaryBackend)
+
+    k_cache = Nx.put_slice(k_cache, [0, 0, offset, 0], k_bn)
+    v_cache = Nx.put_slice(v_cache, [0, 0, offset, 0], v_bn)
+
+    valid_len = offset + seq_len
+    k_valid = Nx.slice_along_axis(k_cache, 0, valid_len, axis: 2)
+    v_valid = Nx.slice_along_axis(v_cache, 0, valid_len, axis: 2)
+
+    groups = div(q_heads, kv_heads)
+    k_repeated = repeat_kv_heads_bn(k_valid, groups)
+    v_repeated = repeat_kv_heads_bn(v_valid, groups)
+
+    scores =
+      q_bn
+      |> Nx.new_axis(3)
+      |> Nx.multiply(Nx.new_axis(k_repeated, 2))
+      |> Nx.sum(axes: [4])
+      |> Nx.multiply(scale)
+      |> apply_causal_mask(offset, seq_len, valid_len)
+
+    weights = softmax_reference(scores, 3)
+
+    attn =
+      weights
+      |> Nx.new_axis(4)
+      |> Nx.multiply(Nx.new_axis(v_repeated, 2))
+      |> Nx.sum(axes: [3])
+
+    attn_out =
+      attn
+      |> Nx.transpose(axes: [0, 2, 1, 3])
+      |> Nx.reshape({batch, seq_len, q_heads * head_dim})
+
+    {attn_out, k_cache, v_cache}
+  end
+
+  defp llama_rope_reference(tensor, dims, offset, rope_freqs) do
+    {_batch, _heads, seq_len, _dims} = Nx.shape(tensor)
+    half = div(dims, 2)
+
+    positions =
+      Nx.iota({seq_len}, type: :f32)
+      |> Nx.add(offset)
+      |> Nx.reshape({seq_len, 1})
+
+    inv_freqs =
+      rope_freqs
+      |> Nx.backend_transfer(Nx.BinaryBackend)
+      |> then(&Nx.divide(1.0, &1))
+      |> Nx.reshape({1, half})
+
+    freqs = Nx.multiply(positions, inv_freqs)
+
+    cos =
+      Nx.concatenate([Nx.cos(freqs), Nx.cos(freqs)], axis: 1)
+      |> Nx.reshape({1, 1, seq_len, dims})
+
+    sin =
+      Nx.concatenate([Nx.sin(freqs), Nx.sin(freqs)], axis: 1)
+      |> Nx.reshape({1, 1, seq_len, dims})
+
+    first = tensor[[.., .., .., 0..(half - 1)//1]]
+    second = tensor[[.., .., .., half..(dims - 1)//1]]
+    rotated = Nx.concatenate([Nx.negate(second), first], axis: 3)
+
+    Nx.add(Nx.multiply(tensor, cos), Nx.multiply(rotated, sin))
+  end
+
+  defp repeat_kv_heads_bn(tensor, 1), do: tensor
+
+  defp repeat_kv_heads_bn(tensor, groups) do
+    {batch, kv_heads, seq_len, head_dim} = Nx.shape(tensor)
+
+    tensor
+    |> Nx.new_axis(2)
+    |> Nx.broadcast({batch, kv_heads, groups, seq_len, head_dim})
+    |> Nx.reshape({batch, kv_heads * groups, seq_len, head_dim})
+  end
+
+  defp apply_causal_mask(scores, offset, seq_len, valid_len) do
+    query_positions =
+      Nx.iota({seq_len}, type: :s32, backend: Nx.BinaryBackend)
+      |> Nx.add(offset)
+      |> Nx.reshape({1, 1, seq_len, 1})
+
+    key_positions =
+      Nx.iota({valid_len}, type: :s32, backend: Nx.BinaryBackend)
+      |> Nx.reshape({1, 1, 1, valid_len})
+
+    mask =
+      key_positions
+      |> Nx.less_equal(query_positions)
+      |> Nx.broadcast(Nx.shape(scores))
+
+    Nx.select(mask, scores, Nx.broadcast(-1.0e9, Nx.shape(scores)))
+  end
+
+  defp softmax_reference(tensor, axis) do
+    shifted = Nx.subtract(tensor, Nx.reduce_max(tensor, axes: [axis], keep_axes: true))
+    exp = Nx.exp(shifted)
+    Nx.divide(exp, Nx.sum(exp, axes: [axis], keep_axes: true))
+  end
+
+  defp llama_layer_reference(
+         hidden,
+         norm1,
+         _q_proj,
+         _k_proj,
+         v_proj,
+         o_proj,
+         norm2,
+         gate_proj,
+         up_proj,
+         down_proj,
+         eps
+       ) do
+    hidden = Nx.backend_transfer(hidden, Nx.BinaryBackend)
+    norm1 = Nx.backend_transfer(norm1, Nx.BinaryBackend)
+    v_proj = Nx.backend_transfer(v_proj, Nx.BinaryBackend)
+    o_proj = Nx.backend_transfer(o_proj, Nx.BinaryBackend)
+
+    xn = rms_norm(hidden, norm1, eps)
+
+    # With a single token at offset 0 there is exactly one key, so causal SDPA
+    # has probability 1.0 and the attention output is the projected value.
+    attn_out = Nx.dot(xn, [2], v_proj, [0])
+    attn_hidden = Nx.add(hidden, Nx.dot(attn_out, [2], o_proj, [0]))
+
+    llama_mlp_reference(attn_hidden, norm2, gate_proj, up_proj, down_proj, eps)
+  end
+
+  defp llama_layer_reference(
+         hidden,
+         norm1,
+         q_proj,
+         k_proj,
+         v_proj,
+         o_proj,
+         k_cache,
+         v_cache,
+         norm2,
+         gate_proj,
+         up_proj,
+         down_proj,
+         offset,
+         scale,
+         head_dim,
+         rope_freqs,
+         eps
+       ) do
+    hidden = Nx.backend_transfer(hidden, Nx.BinaryBackend)
+    norm1 = Nx.backend_transfer(norm1, Nx.BinaryBackend)
+    q_proj = Nx.backend_transfer(q_proj, Nx.BinaryBackend)
+    k_proj = Nx.backend_transfer(k_proj, Nx.BinaryBackend)
+    v_proj = Nx.backend_transfer(v_proj, Nx.BinaryBackend)
+    o_proj = Nx.backend_transfer(o_proj, Nx.BinaryBackend)
+
+    hidden_norm = rms_norm(hidden, norm1, eps)
+    q = hidden_norm |> Nx.dot([2], q_proj, [0]) |> reshape_projection(head_dim)
+    k = hidden_norm |> Nx.dot([2], k_proj, [0]) |> reshape_projection(head_dim)
+    v = hidden_norm |> Nx.dot([2], v_proj, [0]) |> reshape_projection(head_dim)
+
+    {attn_out, k_updated, v_updated} =
+      llama_kv_cache_attention_reference(
+        q,
+        k,
+        v,
+        k_cache,
+        v_cache,
+        offset,
+        scale,
+        head_dim,
+        rope_freqs
+      )
+
+    attn_hidden = Nx.add(hidden, Nx.dot(attn_out, [2], o_proj, [0]))
+
+    {
+      llama_mlp_reference(attn_hidden, norm2, gate_proj, up_proj, down_proj, eps),
+      k_updated,
+      v_updated
+    }
+  end
+
+  defp reshape_projection(tensor, head_dim) do
+    {batch, seq_len, width} = Nx.shape(tensor)
+    Nx.reshape(tensor, {batch, seq_len, div(width, head_dim), head_dim})
+  end
+
+  defp llama_final_greedy_reference(hidden, norm, lm_head, eps) do
+    hidden = Nx.backend_transfer(hidden, Nx.BinaryBackend)
+    {_batch, seq_len, _hidden_size} = Nx.shape(hidden)
+    last_hidden = hidden[[.., (seq_len - 1)..(seq_len - 1)//1, ..]] |> Nx.squeeze(axes: [1])
+    normed = rms_norm(last_hidden, norm, eps)
+    logits = Nx.dot(normed, [1], Nx.backend_transfer(lm_head, Nx.BinaryBackend), [1])
+    Nx.argmax(logits, axis: 1)
+  end
+
+  defp rms_norm(hidden, norm, eps) do
+    variance = hidden |> Nx.pow(2) |> Nx.mean(axes: [-1], keep_axes: true)
+
+    hidden
+    |> Nx.multiply(Nx.rsqrt(Nx.add(variance, eps)))
+    |> Nx.multiply(Nx.backend_transfer(norm, Nx.BinaryBackend))
+  end
+
+  defp gpu_tensor(%Nx.Tensor{} = tensor), do: Nx.backend_transfer(tensor, @backend)
+  defp gpu_tensor(data, type), do: data |> Nx.tensor(type: type) |> Nx.backend_transfer(@backend)
+
+  defp to_binary(ref), do: ref |> EMLX.Backend.to_nx() |> Nx.backend_transfer(Nx.BinaryBackend)
+
+  defp assert_all_close(left, right, opts) do
+    diff =
+      left
+      |> Nx.subtract(right)
+      |> Nx.abs()
+      |> Nx.reduce_max()
+      |> Nx.to_number()
+
+    assert diff <= Keyword.fetch!(opts, :atol)
+  end
+end

--- a/emlx_axon/test/emlx/text_generation_llama_test.exs
+++ b/emlx_axon/test/emlx/text_generation_llama_test.exs
@@ -1,0 +1,177 @@
+defmodule EMLXAxon.TextGenerationLlamaTest do
+  use ExUnit.Case, async: true
+
+  alias EMLXAxon.Llama.DenseLoader
+
+  test "run returns generated text for Llama state" do
+    assert {:ok, state} = dense_state()
+
+    result =
+      EMLXAxon.TextGeneration.run(__MODULE__.FakeTokenizer.new(), state, "hello",
+        max_new_tokens: 2,
+        max_len: 4
+      )
+
+    assert [%{generated_text: text, num_tokens: 2}] = result.results
+    assert is_binary(text)
+  end
+
+  test "stream emits chunks for Llama state" do
+    assert {:ok, state} = stable_dense_state()
+    parent = self()
+
+    result =
+      EMLXAxon.TextGeneration.stream(
+        __MODULE__.FakeTokenizer.new(),
+        state,
+        "hello",
+        fn chunk -> send(parent, {:chunk, chunk}) end,
+        max_new_tokens: 2,
+        max_len: 4,
+        stream_chunking: :token
+      )
+
+    assert result.token_summary.output == 2
+    assert_receive {:chunk, _chunk}
+  end
+
+  test "serving runs Llama state" do
+    assert {:ok, state} = dense_state()
+
+    serving =
+      EMLXAxon.TextGeneration.serving(__MODULE__.FakeTokenizer.new(), state,
+        max_new_tokens: 2,
+        max_len: 4
+      )
+
+    assert %{results: [%{generated_text: text, num_tokens: 2}]} =
+             Nx.Serving.run(serving, "hello")
+
+    assert is_binary(text)
+  end
+
+  test "serving reports Llama finish reason from generation metadata" do
+    assert {:ok, state} = dense_state()
+
+    serving =
+      EMLXAxon.TextGeneration.serving(__MODULE__.FakeTokenizer.new(), state,
+        max_new_tokens: 2,
+        max_len: 4
+      )
+
+    assert %{results: [%{generated_text: text, num_tokens: 2}], finish_reason: finish_reason} =
+             Nx.Serving.run(serving, "hello")
+
+    assert is_binary(text)
+    assert finish_reason in [:length, :stop]
+  end
+
+  test "serving forwards unsupported sampler options to generation" do
+    assert {:ok, state} = dense_state()
+
+    serving =
+      EMLXAxon.TextGeneration.serving(__MODULE__.FakeTokenizer.new(), state,
+        max_new_tokens: 1,
+        max_len: 4,
+        sampler: :top_p_cpu,
+        temperature: :invalid,
+        top_p: 0.9
+      )
+
+    assert catch_error(Nx.Serving.run(serving, "hello"))
+  end
+
+  test "run rejects invalid max_len before cache allocation" do
+    assert {:ok, state} = dense_state()
+
+    for max_len <- [0, -1, 1.5, "4"] do
+      assert_raise ArgumentError, ~r/expected :max_len to be a positive integer/, fn ->
+        EMLXAxon.TextGeneration.run(__MODULE__.FakeTokenizer.new(), state, "hello",
+          max_new_tokens: 1,
+          max_len: max_len
+        )
+      end
+    end
+  end
+
+  defmodule FakeTokenizer do
+    defstruct []
+
+    def new, do: %__MODULE__{}
+
+    def apply(%__MODULE__{}, [_text]) do
+      %{"input_ids" => Nx.tensor([[1]], type: :s64)}
+    end
+
+    def decode(%__MODULE__{}, ids), do: inspect(ids)
+  end
+
+  defp spec do
+    %Bumblebee.Text.Llama{
+      architecture: :for_causal_language_modeling,
+      vocab_size: 16,
+      hidden_size: 4,
+      intermediate_size: 8,
+      attention_head_size: 2,
+      num_blocks: 1,
+      num_attention_heads: 2,
+      num_key_value_heads: 1,
+      rotary_embedding_base: 10_000,
+      layer_norm_epsilon: 1.0e-6,
+      tie_word_embeddings: true
+    }
+  end
+
+  defp dense_state do
+    DenseLoader.from_model_info(%{
+      params: %Axon.ModelState{data: params()},
+      spec: spec()
+    })
+  end
+
+  defp stable_dense_state do
+    DenseLoader.from_model_info(%{
+      params: %Axon.ModelState{data: stable_params()},
+      spec: spec()
+    })
+  end
+
+  defp params do
+    %{}
+    |> put("embedder.token_embedding", "kernel", Nx.iota({16, 4}, type: :f16))
+    |> put("language_modeling_head.output", "kernel", Nx.iota({16, 4}, type: :f16))
+    |> put("output_norm", "weight", ones({4}))
+    |> put("decoder.blocks.0.self_attention_norm", "weight", ones({4}))
+    |> put("decoder.blocks.0.output_norm", "weight", ones({4}))
+    |> put("decoder.blocks.0.self_attention.query", "kernel", Nx.iota({4, 4}, type: :f16))
+    |> put("decoder.blocks.0.self_attention.key", "kernel", Nx.iota({4, 2}, type: :f16))
+    |> put("decoder.blocks.0.self_attention.value", "kernel", Nx.iota({4, 2}, type: :f16))
+    |> put("decoder.blocks.0.self_attention.output", "kernel", Nx.iota({4, 4}, type: :f16))
+    |> put("decoder.blocks.0.ffn.gate", "kernel", Nx.iota({4, 8}, type: :f16))
+    |> put("decoder.blocks.0.ffn.intermediate", "kernel", Nx.iota({4, 8}, type: :f16))
+    |> put("decoder.blocks.0.ffn.output", "kernel", Nx.iota({8, 4}, type: :f16))
+  end
+
+  defp stable_params do
+    %{}
+    |> put("embedder.token_embedding", "kernel", zeros({16, 4}))
+    |> put("language_modeling_head.output", "kernel", zeros({16, 4}))
+    |> put("output_norm", "weight", ones({4}))
+    |> put("decoder.blocks.0.self_attention_norm", "weight", ones({4}))
+    |> put("decoder.blocks.0.output_norm", "weight", ones({4}))
+    |> put("decoder.blocks.0.self_attention.query", "kernel", zeros({4, 4}))
+    |> put("decoder.blocks.0.self_attention.key", "kernel", zeros({4, 2}))
+    |> put("decoder.blocks.0.self_attention.value", "kernel", zeros({4, 2}))
+    |> put("decoder.blocks.0.self_attention.output", "kernel", zeros({4, 4}))
+    |> put("decoder.blocks.0.ffn.gate", "kernel", zeros({4, 8}))
+    |> put("decoder.blocks.0.ffn.intermediate", "kernel", zeros({4, 8}))
+    |> put("decoder.blocks.0.ffn.output", "kernel", zeros({8, 4}))
+  end
+
+  defp ones(shape), do: Nx.broadcast(Nx.tensor(1.0, type: :f16), shape)
+  defp zeros(shape), do: Nx.broadcast(Nx.tensor(0.0, type: :f16), shape)
+
+  defp put(params, scope, name, tensor) do
+    Map.update(params, scope, %{name => tensor}, &Map.put(&1, name, tensor))
+  end
+end


### PR DESCRIPTION
Adds an end to end native dense generation path for Llama 3.2 style checkpoints in `emlx_axon`.

This includes:

- dense Llama safetensors loading
- native Llama model state and generation loop
- an `emlx_axon` Llama compute plugin
- EMLX native ABI support needed by the plugin
- TextGeneration dispatch for Qwen3 and Llama states
- strict benchmark support for dense Llama validation
- focused loader, generation, native math, and TextGeneration tests

The goal is to keep the user facing model path in `emlx_axon`, while using native MLX support where it materially improves generation speed.

Benchmark was run on an Apple M4 Max with 128 GB RAM, using `meta-llama/Llama-3.2-1B` from local Hugging Face safetensors, f16, on the EMLX GPU backend.

The benchmark was run in strict length mode, so all paths generated exactly `64` tokens with the same prompt, tokenizer, generation config, device, precision, and greedy decoding.

Command:

```sh
cd emlx_axon
EMLX_AXON_LOCAL_EMLX=true \
EMLX_DENSE_LLAMA_MODEL=/path/to/local/Llama-3.2-1B/snapshot \
EMLX_DENSE_LLAMA_DEVICE=gpu \
EMLX_DENSE_LLAMA_TYPE=f16 \
EMLX_DENSE_LLAMA_SEQUENCE_LENGTH=128 \
EMLX_DENSE_LLAMA_MAX_NEW=64 \
EMLX_DENSE_LLAMA_RUNS=5 \
EMLX_DENSE_LLAMA_WARMUP_RUNS=1 \
EMLX_DENSE_LLAMA_STRICT_LENGTH=true \
EMLX_DENSE_LLAMA_JSON=/tmp/llama_dense_strict.json \
mix run bench/validate_llama_dense.exs
```

Results:

- stock Bumblebee + EMLX: `96.199 tok/s` p50, `665.287 ms` p50 duration
- EMLXAxon rewrite path: `130.486 tok/s` p50, `490.473 ms` p50 duration
- native dense Llama path: `172.203 tok/s` p50, `371.654 ms` p50 duration

All three paths generated `64` tokens in every measured run and all finished with `length`.

The native dense path is about `1.79x` faster than stock Bumblebee + EMLX and about `1.32x` faster than the existing EMLXAxon rewrite path in this strict comparison.

Validation:

```sh
cd emlx_axon
EMLX_AXON_LOCAL_EMLX=true EMLX_TEST_DEFAULT_GPU=true \
  mix test --exclude quantized_inference --warnings-as-errors

EMLX_AXON_LOCAL_EMLX=true \
  mix format --check-formatted mix.exs lib test bench
```

Result:

- `138 passed, 2 excluded`
- formatting check passed

Note: CI uses the sibling `emlx` dependency through `EMLX_AXON_LOCAL_EMLX=true` because this PR adds the `emlx` native ABI support and the `emlx_axon` plugin that depends on it in the same branch. Before release, `emlx_axon` should depend on the next `emlx` version that contains this ABI.
