### PR TITLE
fix: update to Nx 0.13, replace :token/:attach_token with :io_call

### DIFF
--- a/emlx/lib/emlx/native/expr.ex
+++ b/emlx/lib/emlx/native/expr.ex
@@ -2011,7 +2011,8 @@ defmodule EMLX.Native.Expr do
   # `EMLX.Native.Expr.t/0`'s `keepalive_refs` doc for where the final tip of
   # this chain ends up.
   defp expand_node(
-         %T{data: %Nx.Defn.Expr{id: id, op: :token, args: [%Nx.Defn.Token{hooks: hooks}]}},
+         %T{data: %Nx.Defn.Expr{id: id, op: :io_call,
+              args: [tensor_expr, callback_spec, _template, _ref]}},
          state
        ) do
     unless MapSet.member?(state.top_scope_ids, id) do
@@ -2023,34 +2024,19 @@ defmodule EMLX.Native.Expr do
               "branch's hook). Move the hook outside the cond."
     end
 
-    # `token.hooks` stores the most-recently-declared hook at the head (see
-    # Nx.Defn.Token's moduledoc) -- reverse to chain them in true declaration
-    # order.
-    Enum.reduce(Enum.reverse(hooks), state, fn
-      %{callback: nil}, state ->
-        state
+    case callback_spec do
+      {:fn, fun} ->
+        state = emit_hook_runtime_call(tensor_expr, fun, state)
+        set_io_call_ref(id, tensor_expr, state)
 
-      %{callback: callback, expr: expr}, state ->
-        emit_hook_runtime_call(expr, callback, state)
-    end)
-  end
+      {:named, _name, nil} ->
+        ref = Map.fetch!(state.node_to_ref, tensor_expr.data.id)
+        %{state | node_to_ref: Map.put(state.node_to_ref, id, ref)}
 
-  # Resolves to the hooked (post-side-effect) value when `expr` is one of
-  # *this* token's own hooked expressions -- see `emit_hook_runtime_call/3`'s
-  # `hooked_value_refs` doc -- falling back to the plain ref otherwise (a
-  # name-only hook with no callback, or `attach_token` wrapping something
-  # that isn't itself hooked).
-  defp expand_node(
-         %T{data: %Nx.Defn.Expr{id: id, op: :attach_token, args: [_token, expr]}},
-         state
-       ) do
-    ref =
-      case Map.fetch(state.hooked_value_refs, expr.data.id) do
-        {:ok, hooked_ref} -> hooked_ref
-        :error -> Map.fetch!(state.node_to_ref, expr.data.id)
-      end
-
-    %{state | node_to_ref: Map.put(state.node_to_ref, id, ref)}
+      {:named, _name, callback} when is_function(callback, 1) ->
+        state = emit_hook_runtime_call(tensor_expr, callback, state)
+        set_io_call_ref(id, tensor_expr, state)
+    end
   end
 
   defp expand_node(
@@ -2156,6 +2142,19 @@ defmodule EMLX.Native.Expr do
 
   defp expand_node(%T{data: %Nx.Defn.Expr{op: op}}, _state) do
     raise ArgumentError, "does not yet lower op #{inspect(op)}"
+  end
+
+  defp set_io_call_ref(id, tensor_expr, state) do
+    leaves = Composite.flatten_list([tensor_expr])
+    leaf_refs =
+      Enum.map(leaves, fn leaf ->
+        Map.fetch!(state.hooked_value_refs, leaf.data.id)
+      end)
+
+    case leaf_refs do
+      [single_ref] -> %{state | node_to_ref: Map.put(state.node_to_ref, id, single_ref)}
+      refs -> %{state | node_to_ref: Map.put(state.node_to_ref, id, refs)}
+    end
   end
 
   # Emits one `:runtime_call` instruction from already-resolved operand refs
@@ -2818,8 +2817,12 @@ defmodule EMLX.Native.Expr do
     container
     |> EMLX.Defn.Tree.post_order(&scope_dependencies/1)
     |> Enum.any?(fn
-      %T{data: %Nx.Defn.Expr{op: :token, args: [%Nx.Defn.Token{hooks: hooks}]}} ->
-        Enum.any?(hooks, &(&1.callback != nil))
+      %T{data: %Nx.Defn.Expr{op: :io_call, args: [_, callback_spec, _, _]}} ->
+        case callback_spec do
+          {:fn, _} -> true
+          {:named, _, callback} when is_function(callback, 1) -> true
+          _ -> false
+        end
 
       _ ->
         false

--- a/emlx/mix.exs
+++ b/emlx/mix.exs
@@ -70,7 +70,7 @@ defmodule EMLX.MixProject do
     [
       {:elixir_make, "~> 0.6"},
       {:fine, "~> 0.1", runtime: false},
-      {:nx, "~> 0.12"},
+      {:nx, "~> 0.13"},
       {:telemetry, "~> 1.0"},
       {:ex_doc, "~> 0.34", only: :docs}
     ]


### PR DESCRIPTION
### Problem

EMLX 0.4.0 depends on `nx ~> 0.12` and references `Nx.Defn.Token`, which was
removed in Nx 0.13. The `:token` and `:attach_token` expression ops were
replaced by a single `:io_call` op.

Compiling EMLX with Nx 0.13 gives:

```
** (CompileError) cannot expand Nx.Defn.Token, module not available
```

### Changes

**`mix.exs`**: Updated version constraint from `~> 0.12` to `~> 0.13`.

**`lib/emlx/native/expr.ex`** (3 changes):

1. **`:token` → `:io_call`** (`expand_node`): Replaced the `:token` match
   (which iterated `%Nx.Defn.Token{hooks: hooks}` and fired each hook's
   callback) with a match on `:io_call`. The new clause extracts the callback
   from `callback_spec` (which can be `{:fn, fun}`, `{:named, name, nil}`, or
   `{:named, name, callback}`) and calls `emit_hook_runtime_call` accordingly.

2. **Removed `:attach_token`** (`expand_node`): In Nx 0.13, `:io_call`'s
   output is the hooked value directly — there is no separate attach step.
   The old `hooked_value_refs` lookup logic is replaced by `set_io_call_ref/3`,
   which maps the `:io_call` node's id to the post-hook MLX ref.

3. **`while_scope_contains_hook?`**: Updated the pattern match from
   `:token` + `Nx.Defn.Token` to `:io_call` + `callback_spec`.

### Testing

- All existing EMLX tests pass (when run against Nx 0.13).
- `Nx.top_k` benchmark runs correctly on EMLX (`Nx.Defn.jit` + GPU).
- `io_call` in `defn` context correctly preserves the side-effect semantics
  (callback fires, output value unchanged).
- Chain of multiple `io_call` nodes, name-only hooks (`:named`),
  and function hooks (`:fn`) all verified.

### Code Review Notes

The `set_io_call_ref/3` helper is placed after the fallback `expand_node/2`
clause to avoid breaking Elixir's function clause grouping rules.

---

*Assisted by DeepSeek V4 Flash*