### PR TITLE
Add gather_qmm for mixture-of-experts layers

### DIFF
--- a/emlx/c_src/emlx_nif.cpp
+++ b/emlx/c_src/emlx_nif.cpp
@@ -1386,6 +1386,42 @@ NIF(as_strided) {
 // mode: "affine" (default, real biases) or a microscaled variant
 // ("mxfp4"/"mxfp8"/"nvfp4" — no biases; mx::fp_quantize returns only
 // (wq, scales)). biases is `nil` from Elixir for microscaled modes.
+// gather_qmm - quantized matmul where each row picks which weight matrix to
+// use. This is the primitive behind mixture-of-experts: `w` holds every
+// expert, `rhs_indices` says which expert each token routes to, and the
+// gather happens inside the kernel instead of materialising a per-token copy
+// of the weights.
+// MLX API: gather_qmm(x, w, scales, biases, lhs_indices, rhs_indices,
+//                     transpose, group_size, bits, mode, sorted_indices, stream)
+NIF(gather_qmm) {
+  TENSOR_PARAM(0, x);       // Input tensor [batch, seq, hidden]
+  TENSOR_PARAM(1, w);       // Quantized experts [num_experts, out/8, in]
+  TENSOR_PARAM(2, scales);  // Per-group scales
+  OPTIONAL_TENSOR_PARAM(3, biases);       // nil for microscaled modes
+  OPTIONAL_TENSOR_PARAM(4, lhs_indices);  // nil selects rows in order
+  OPTIONAL_TENSOR_PARAM(5, rhs_indices);  // expert id per row
+  PARAM(6, bool, transpose);
+  PARAM(7, int, group_size);
+  PARAM(8, int, bits);
+  std::string mode;
+  if (!nx::nif::get(env, argv[9], mode)) {
+    return nx::nif::error(env, "Unable to get mode param.");
+  }
+  PARAM(10, bool, sorted_indices);
+  DEVICE_PARAM(11, device);
+
+  std::optional<mlx::core::array> biases_opt =
+      biases ? std::make_optional(*biases) : std::nullopt;
+  std::optional<mlx::core::array> lhs_opt =
+      lhs_indices ? std::make_optional(*lhs_indices) : std::nullopt;
+  std::optional<mlx::core::array> rhs_opt =
+      rhs_indices ? std::make_optional(*rhs_indices) : std::nullopt;
+
+  TENSOR(mlx::core::gather_qmm(*x, *w, *scales, biases_opt, lhs_opt, rhs_opt,
+                               transpose, group_size, bits, mode,
+                               sorted_indices, device));
+}
+
 NIF(quantized_matmul) {
   TENSOR_PARAM(0, x);       // Input tensor [batch, seq, hidden]
   TENSOR_PARAM(1, w);       // Quantized weights [out/8, in] (uint32 packed)
@@ -1457,6 +1493,7 @@ NIF(quantize) {
   CATCH()
 }
 
+ASYNC_NIF(gather_qmm)
 ASYNC_NIF(quantized_matmul)
 ASYNC_NIF(dequantize)
 ASYNC_NIF(quantize)
@@ -2010,6 +2047,7 @@ static ErlNifFunc nif_funcs[] = {
     {"command_queue_new", 1, command_queue_new},
     {"command_queue_synchronize", 1, command_queue_synchronize},
     // Quantization operations (async — must run on a worker thread)
+    {"gather_qmm", 13, gather_qmm_async},
     {"quantized_matmul", 10, quantized_matmul_async},
     {"dequantize", 8, dequantize_async},
     {"quantize", 6, quantize_async},

--- a/emlx/lib/emlx.ex
+++ b/emlx/lib/emlx.ex
@@ -1379,6 +1379,57 @@ defmodule EMLX do
     EMLX.Backend.to_nx(result)
   end
 
+  @doc """
+  Run `gather_qmm` at the `Nx.Tensor` level: pick an expert per row, then
+  multiply.
+
+  `qw` must be a quantized tensor produced by `EMLX.quantize/2` whose leading
+  axis stacks the experts. `rhs_indices` names the expert for each row; pass
+  `lhs_indices` to reorder the activation rows as well, or `nil` to take them
+  in order. Set `:sorted_indices` when `rhs_indices` is already sorted so the
+  kernel can skip its own sort.
+  """
+  def gather_quantized_matmul(
+        %Nx.Tensor{} = activation,
+        %Nx.Tensor{} = qw,
+        %Nx.Tensor{} = rhs_indices,
+        opts \\ []
+      ) do
+    opts = Keyword.validate!(opts, lhs_indices: nil, sorted_indices: false)
+    cfg = qw.data.quantization_config
+
+    if is_nil(cfg) do
+      raise ArgumentError,
+            "EMLX.gather_quantized_matmul/4: second argument must be a quantized tensor"
+    end
+
+    if not is_nil(activation.data.quantization_config) do
+      raise ArgumentError,
+            "EMLX.gather_quantized_matmul/4 requires a dense activation as the " <>
+              "first argument; got two quantized tensors. Dequantize one of them first."
+    end
+
+    lhs_ref = opts[:lhs_indices] && EMLX.Backend.from_nx(opts[:lhs_indices])
+    biases_ref = cfg.biases && EMLX.Backend.from_nx(cfg.biases)
+
+    result =
+      EMLX.gather_qmm(
+        EMLX.Backend.from_nx(activation),
+        qw.data.ref,
+        EMLX.Backend.from_nx(cfg.scales),
+        biases_ref,
+        lhs_ref,
+        EMLX.Backend.from_nx(rhs_indices),
+        true,
+        cfg.group_size,
+        cfg.bits,
+        cfg.mode,
+        opts[:sorted_indices]
+      )
+
+    EMLX.Backend.to_nx(result)
+  end
+
   def to_blob({device, ref} = tensor) when is_tensor(device, ref) do
     maybe_profile(EMLX.Profiling.inc_to_blob())
     # Eval first so the underlying MLX array is materialised; then ask the

--- a/emlx/lib/emlx.ex
+++ b/emlx/lib/emlx.ex
@@ -436,6 +436,64 @@ defmodule EMLX do
   ## Quantization operations (for 4-bit model support)
 
   @doc """
+  Quantized matmul with per-row expert selection (`mx::gather_qmm`).
+
+  Same contract as `quantized_matmul/8`, plus two index tensors. `w` carries
+  every expert stacked on a leading axis; `rhs_indices` picks the expert for
+  each row of `x`, and `lhs_indices` picks the row of `x` (pass `nil` to take
+  them in order). Set `sorted_indices` when `rhs_indices` is already sorted —
+  the kernel then skips its own sort.
+
+  This is what a mixture-of-experts layer needs: the gather happens inside the
+  kernel, so no per-token copy of the expert weights is ever materialised.
+  """
+  @mlx_function {:gather_qmm, 13}
+  def gather_qmm(
+        {dev_x, ref_x} = _tensor_x,
+        {dev_w, ref_w} = _tensor_w,
+        {dev_s, ref_s} = _tensor_scales,
+        biases,
+        lhs_indices,
+        rhs_indices,
+        transpose \\ true,
+        group_size \\ 64,
+        bits \\ 4,
+        mode \\ "affine",
+        sorted_indices \\ false
+      )
+      when is_tensor(dev_x, ref_x) and is_tensor(dev_w, ref_w) and is_tensor(dev_s, ref_s) do
+    {ref_b, biases_device} = unwrap_optional_tensor(biases)
+    {ref_lhs, lhs_device} = unwrap_optional_tensor(lhs_indices)
+    {ref_rhs, rhs_device} = unwrap_optional_tensor(rhs_indices)
+
+    device =
+      [dev_x, dev_w, dev_s, biases_device, lhs_device, rhs_device]
+      |> Enum.reduce(&merge_device(&2, &1))
+
+    {worker, effective_device} = resolve_worker(device)
+
+    job_ref =
+      EMLX.NIF.gather_qmm(
+        worker,
+        ref_x,
+        ref_w,
+        ref_s,
+        ref_b,
+        ref_lhs,
+        ref_rhs,
+        transpose,
+        group_size,
+        bits,
+        mode,
+        sorted_indices,
+        effective_device
+      )
+      |> unwrap!()
+
+    await_worker(job_ref) |> wrap_tensor(effective_device)
+  end
+
+  @doc """
   Performs quantized matrix multiplication.
 
   This is the key operation for efficient 4-bit inference. It multiplies `x` with

--- a/emlx/lib/emlx.ex
+++ b/emlx/lib/emlx.ex
@@ -1250,7 +1250,11 @@ defmodule EMLX do
   end
 
   @doc """
-  Quantize a dense 2-D `Nx.Tensor` and return an annotated quantized tensor.
+  Quantize a dense `Nx.Tensor` of rank 2 or higher and return an annotated
+  quantized tensor.
+
+  Quantization runs along the last axis. Leading axes are batch or stacking
+  dimensions.
 
   The returned tensor carries the original logical shape and type (e.g.
   `{:s, 4}`). Its backend stores the packed uint32 data and a
@@ -1277,12 +1281,12 @@ defmodule EMLX do
     validate_quantization_mode!(mode)
     validate_microscaled_constraints!(mode, group_size, bits)
 
-    unless Nx.rank(tensor) == 2 do
+    unless Nx.rank(tensor) >= 2 do
       raise ArgumentError,
-            "EMLX.quantize/2 requires a rank-2 tensor, got rank #{Nx.rank(tensor)}"
+            "EMLX.quantize/2 requires a tensor of rank 2 or higher, got rank #{Nx.rank(tensor)}"
     end
 
-    {_out_features, in_features} = Nx.shape(tensor)
+    in_features = Nx.axis_size(tensor, -1)
 
     unless rem(in_features, group_size) == 0 do
       raise ArgumentError,

--- a/emlx/lib/emlx/quantization.ex
+++ b/emlx/lib/emlx/quantization.ex
@@ -61,7 +61,10 @@ defmodule EMLX.Quantization do
   alias EMLX.Quantization.Config
 
   @doc """
-  Quantize a dense 2-D tensor via `Nx.runtime_call`.
+  Quantize a dense tensor of rank 2 or higher via `Nx.runtime_call`.
+
+  Quantization runs along the last axis; leading axes are batch or stacking
+  dims.
 
   At execution time the callback receives the real tensor and runs
   `mx::quantize`. Returns an annotated quantized `Nx.Tensor` with the same

--- a/emlx/lib/emlx/quantization.ex
+++ b/emlx/lib/emlx/quantization.ex
@@ -310,6 +310,77 @@ defmodule EMLX.Quantization do
   end
 
   @doc """
+  Run a gathered quantized matmul via `Nx.runtime_call`.
+
+  The mixture-of-experts counterpart of `quantized_matmul/2`: `qw` stacks every
+  expert on its leading axis and `rhs_indices` names the expert for each row,
+  so the gather happens inside `mx::gather_qmm` and no per-token copy of the
+  expert weights is ever materialised. Safe inside `Nx.Defn.jit`-traced
+  forward passes.
+
+  Output shape is `{batch_dims..., rows, out_features}`, where the batch dims
+  come from broadcasting the activation's leading axes against `rhs_indices`
+  and `out_features` is the second dimension of `qw`. Output type follows the
+  same rule as `quantized_matmul/2`.
+
+  ## Options
+
+    * `:lhs_indices` - reorders the activation rows; `nil` takes them in order
+    * `:sorted_indices` - set when `rhs_indices` is already sorted, so the
+      kernel can skip its own sort
+  """
+  deftransform gather_quantized_matmul(activation, qw, rhs_indices, opts \\ []) do
+    opts = Keyword.validate!(opts, lhs_indices: nil, sorted_indices: false)
+
+    {_experts, out_features, _in_features} = Nx.shape(qw)
+
+    act_dims = Nx.shape(activation) |> Tuple.to_list()
+    {act_batch, [rows, _cols]} = Enum.split(act_dims, -2)
+    act_batch = List.to_tuple(act_batch)
+    idx_shape = Nx.shape(rhs_indices)
+
+    # Same right-aligned rule MLX applies to the batch axes inside the kernel.
+    {batch, _names} =
+      Nx.Shape.binary_broadcast(
+        act_batch,
+        List.duplicate(nil, tuple_size(act_batch)),
+        idx_shape,
+        List.duplicate(nil, tuple_size(idx_shape))
+      )
+
+    out_shape = List.to_tuple(Tuple.to_list(batch) ++ [rows, out_features])
+
+    out_type =
+      case qw do
+        %Nx.Tensor{data: %EMLX.Backend{quantization_config: %Config{mode: "affine", scales: s}}} ->
+          Nx.type(s)
+
+        %Nx.Tensor{data: %EMLX.Backend{quantization_config: %Config{}}} ->
+          Nx.type(activation)
+
+        _ ->
+          Nx.Type.merge(Nx.type(activation), Nx.type(qw))
+      end
+
+    out = Nx.template(out_shape, out_type)
+
+    Nx.runtime_call(
+      out,
+      {activation, qw, rhs_indices},
+      opts,
+      &__MODULE__.gather_quantized_matmul_callback/2
+    )
+  end
+
+  @doc false
+  def gather_quantized_matmul_callback(
+        {%Nx.Tensor{} = activation, %Nx.Tensor{} = qw, %Nx.Tensor{} = rhs_indices},
+        opts
+      ) do
+    EMLX.gather_quantized_matmul(activation, qw, rhs_indices, opts)
+  end
+
+  @doc """
   Returns `true` if the tensor has quantization metadata on its backend.
   """
   def quantized?(%Nx.Tensor{data: %EMLX.Backend{quantization_config: cfg}}) when not is_nil(cfg),

--- a/emlx/test/emlx/gather_qmm_test.exs
+++ b/emlx/test/emlx/gather_qmm_test.exs
@@ -1,0 +1,111 @@
+defmodule EMLX.GatherQmmTest do
+  @moduledoc """
+  Tests for `EMLX.gather_qmm/11` — quantized matmul with per-row weight
+  selection (`mx::gather_qmm`), the primitive behind mixture-of-experts layers.
+  """
+  use EMLX.Case, async: true
+
+  @moduletag :metal
+
+  # Device refs are consumed by the NIF, so every call gets a fresh one.
+  # backend_copy, not backend_transfer: the latter moves the tensor and leaves
+  # the source deallocated, which breaks the second use of the same input.
+  defp ref(tensor) do
+    tensor
+    |> Nx.backend_copy({EMLX.Backend, device: :gpu})
+    |> EMLX.Backend.from_nx()
+  end
+
+  # Stacked per-expert weights: {experts, out, in}. Returned as a plain tensor
+  # and quantized at each point of use.
+  defp expert_weights(count, out, inp) do
+    Nx.iota({count, out, inp}, type: :f32)
+    |> Nx.divide(count * out * inp)
+    |> Nx.subtract(0.5)
+  end
+
+  defp quantized(weights), do: EMLX.quantize(ref(weights), 64, 4)
+
+  defp gather(x, weights, indices, opts \\ []) do
+    {w, scales, biases} = quantized(weights)
+
+    EMLX.gather_qmm(
+      ref(x),
+      w,
+      scales,
+      biases,
+      nil,
+      ref(indices),
+      true,
+      64,
+      4,
+      "affine",
+      Keyword.get(opts, :sorted, false)
+    )
+    |> EMLX.Backend.to_nx()
+  end
+
+  describe "EMLX.gather_qmm/11" do
+    test "each row uses the expert named by rhs_indices" do
+      weights = expert_weights(4, 32, 128)
+      x = Nx.iota({4, 1, 1, 128}, type: :f32) |> Nx.divide(128)
+      indices = Nx.tensor([[0], [1], [2], [3]], type: :u32)
+
+      gathered = gather(x, weights, indices)
+      assert Nx.shape(gathered) == {4, 1, 1, 32}
+
+      # Each row must match a plain quantized_matmul against that expert alone.
+      for expert <- 0..3 do
+        row = x |> Nx.slice([expert, 0, 0, 0], [1, 1, 1, 128]) |> Nx.reshape({1, 128})
+        one = weights |> Nx.slice([expert, 0, 0], [1, 32, 128]) |> Nx.reshape({32, 128})
+        {w, scales, biases} = quantized(one)
+
+        direct =
+          EMLX.quantized_matmul(ref(row), w, scales, biases, true, 64, 4)
+          |> EMLX.Backend.to_nx()
+
+        taken = gathered |> Nx.slice([expert, 0, 0, 0], [1, 1, 1, 32]) |> Nx.reshape({1, 32})
+        assert Nx.all_close(taken, direct, atol: 1.0e-5) |> Nx.to_number() == 1
+      end
+    end
+
+    test "repeated indices produce identical rows" do
+      weights = expert_weights(4, 32, 128)
+      x = Nx.iota({1, 1, 1, 128}, type: :f32) |> Nx.divide(128)
+
+      out = gather(x, weights, Nx.tensor([[2, 2, 2]], type: :u32))
+      assert Nx.shape(out) == {1, 3, 1, 32}
+
+      first = Nx.slice(out, [0, 0, 0, 0], [1, 1, 1, 32])
+
+      for k <- 1..2 do
+        other = Nx.slice(out, [0, k, 0, 0], [1, 1, 1, 32])
+        assert Nx.all_close(first, other) |> Nx.to_number() == 1
+      end
+    end
+
+    test "sorted_indices does not change the result" do
+      weights = expert_weights(8, 32, 128)
+      x = Nx.iota({4, 1, 1, 128}, type: :f32) |> Nx.divide(128)
+      indices = Nx.tensor([[0, 1], [2, 3], [4, 5], [6, 7]], type: :u32)
+
+      unsorted = gather(x, weights, indices, sorted: false)
+      sorted = gather(x, weights, indices, sorted: true)
+
+      assert Nx.all_close(unsorted, sorted, atol: 1.0e-5) |> Nx.to_number() == 1
+    end
+
+    test "output shape follows the index shape" do
+      weights = expert_weights(8, 32, 128)
+      x = Nx.iota({2, 1, 1, 128}, type: :f32) |> Nx.divide(128)
+
+      for per_row <- [1, 2, 4] do
+        indices =
+          Nx.iota({2, per_row}, type: :u32)
+          |> Nx.remainder(Nx.tensor(8, type: :u32))
+
+        assert Nx.shape(gather(x, weights, indices)) == {2, per_row, 1, 32}
+      end
+    end
+  end
+end

--- a/emlx/test/emlx/gather_quantized_matmul_test.exs
+++ b/emlx/test/emlx/gather_quantized_matmul_test.exs
@@ -1,0 +1,106 @@
+defmodule EMLX.GatherQuantizedMatmulTest do
+  @moduledoc """
+  Tests for `EMLX.Quantization.gather_quantized_matmul/4` — the `Nx.Tensor`
+  level entry point for `mx::gather_qmm`, usable inside compiled numerical
+  definitions.
+  """
+  use EMLX.Case, async: true
+
+  @moduletag :metal
+
+  # One weight matrix per expert, packed the way a checkpoint delivers them:
+  # `EMLX.quantize/2` takes a single matrix, so the stack goes through the
+  # device-level call and `quantized_tensor/5`, which is what that function is
+  # documented for.
+  defp stacked_experts(count, out, inp) do
+    dense =
+      Nx.iota({count, out, inp}, type: :f32)
+      |> Nx.divide(count * out * inp)
+      |> Nx.subtract(0.5)
+      |> EMLX.Backend.from_nx()
+
+    {weight_ref, scales_ref, biases_ref} = EMLX.quantize(dense, 64, 4)
+
+    EMLX.Quantization.quantized_tensor(
+      weight_ref,
+      scales_ref,
+      biases_ref,
+      {count, out, inp},
+      group_size: 64
+    )
+  end
+
+  # Each row multiplied by its own expert, spelled out with dense matmuls.
+  defp reference(x, qw, indices) do
+    dense = EMLX.Quantization.dequantize(qw)
+
+    indices
+    |> Nx.to_flat_list()
+    |> Enum.with_index()
+    |> Enum.map(fn {expert, row} -> Nx.dot(x[row], [2], dense[expert], [1]) end)
+    |> Nx.stack()
+  end
+
+  describe "gather_quantized_matmul/4" do
+    test "matches a dense per-expert reference" do
+      qw = stacked_experts(4, 32, 128)
+      x = Nx.iota({4, 1, 1, 128}, type: :f32) |> Nx.divide(128)
+      indices = Nx.tensor([[0], [1], [2], [3]], type: :u32)
+
+      got = EMLX.Quantization.gather_quantized_matmul(x, qw, indices)
+
+      assert Nx.shape(got) == {4, 1, 1, 32}
+      assert_all_close(got, reference(x, qw, indices), atol: 1.0e-3)
+    end
+
+    test "the same expert may be named by several rows" do
+      qw = stacked_experts(4, 16, 64)
+      x = Nx.iota({4, 1, 1, 64}, type: :f32) |> Nx.divide(64)
+      indices = Nx.tensor([[2], [2], [0], [2]], type: :u32)
+
+      got = EMLX.Quantization.gather_quantized_matmul(x, qw, indices)
+
+      assert_all_close(got, reference(x, qw, indices), atol: 1.0e-3)
+    end
+
+    test "runs inside a compiled numerical definition" do
+      qw = stacked_experts(4, 32, 128)
+      x = Nx.iota({4, 1, 1, 128}, type: :f32) |> Nx.divide(128)
+      indices = Nx.tensor([[0], [1], [2], [3]], type: :u32)
+
+      fun =
+        Nx.Defn.compile(
+          &EMLX.Quantization.gather_quantized_matmul/3,
+          [x, qw, indices],
+          compiler: EMLX
+        )
+
+      assert_equal(
+        fun.(x, qw, indices),
+        EMLX.Quantization.gather_quantized_matmul(x, qw, indices)
+      )
+    end
+
+    test "sorted_indices takes the same path when indices are ordered" do
+      qw = stacked_experts(4, 16, 64)
+      x = Nx.iota({4, 1, 1, 64}, type: :f32) |> Nx.divide(64)
+      indices = Nx.tensor([[0], [1], [2], [3]], type: :u32)
+
+      assert_all_close(
+        EMLX.Quantization.gather_quantized_matmul(x, qw, indices, sorted_indices: true),
+        EMLX.Quantization.gather_quantized_matmul(x, qw, indices),
+        atol: 1.0e-3
+      )
+    end
+
+    test "rejects a dense second argument" do
+      x = Nx.iota({4, 1, 1, 64}, type: :f32)
+      dense = Nx.iota({4, 16, 64}, type: :f32)
+      indices = Nx.tensor([[0], [1], [2], [3]], type: :u32)
+
+      assert_raise ArgumentError, ~r/must be a quantized tensor/, fn ->
+        EMLX.Quantization.gather_quantized_matmul(x, dense, indices)
+      end
+    end
+  end
+end

--- a/emlx/test/emlx/gather_quantized_matmul_test.exs
+++ b/emlx/test/emlx/gather_quantized_matmul_test.exs
@@ -8,26 +8,11 @@ defmodule EMLX.GatherQuantizedMatmulTest do
 
   @moduletag :metal
 
-  # One weight matrix per expert, packed the way a checkpoint delivers them:
-  # `EMLX.quantize/2` takes a single matrix, so the stack goes through the
-  # device-level call and `quantized_tensor/5`, which is what that function is
-  # documented for.
   defp stacked_experts(count, out, inp) do
-    dense =
-      Nx.iota({count, out, inp}, type: :f32)
-      |> Nx.divide(count * out * inp)
-      |> Nx.subtract(0.5)
-      |> EMLX.Backend.from_nx()
-
-    {weight_ref, scales_ref, biases_ref} = EMLX.quantize(dense, 64, 4)
-
-    EMLX.Quantization.quantized_tensor(
-      weight_ref,
-      scales_ref,
-      biases_ref,
-      {count, out, inp},
-      group_size: 64
-    )
+    Nx.iota({count, out, inp}, type: :f32)
+    |> Nx.divide(count * out * inp)
+    |> Nx.subtract(0.5)
+    |> EMLX.quantize([])
   end
 
   # Each row multiplied by its own expert, spelled out with dense matmuls.

--- a/emlx/test/emlx/quantization_module_test.exs
+++ b/emlx/test/emlx/quantization_module_test.exs
@@ -47,13 +47,26 @@ defmodule EMLX.Quantization.ModuleTest do
       assert Nx.shape(cfg.biases) == {128, 2}
     end
 
-    test "raises on non-rank-2 tensor" do
-      weight = Nx.iota({2, 64, 64}, type: :f32)
+    test "raises on rank-1 tensor" do
+      weight = Nx.iota({64}, type: :f32)
       weight = Nx.backend_transfer(weight, {EMLX.Backend, device: :gpu})
 
-      assert_raise ArgumentError, ~r/rank-2/, fn ->
+      assert_raise ArgumentError, ~r/rank 2 or higher/, fn ->
         EMLX.quantize(weight, [])
       end
+    end
+
+    test "quantizes and dequantizes a rank-3 tensor" do
+      weight = Nx.iota({4, 32, 64}, type: :f32) |> Nx.divide(100)
+      weight = Nx.backend_transfer(weight, {EMLX.Backend, device: :gpu})
+
+      qw = EMLX.quantize(weight, [])
+
+      assert Nx.shape(qw) == {4, 32, 64}
+      assert Quantization.quantized?(qw)
+
+      dense = Quantization.dequantize(qw)
+      assert Nx.shape(dense) == {4, 32, 64}
     end
 
     test "raises when in_features not divisible by group_size" do


### PR DESCRIPTION
`mx::gather_qmm` is a quantized matmul where each row selects which weight
matrix to use. It is the primitive a mixture-of-experts layer needs: the expert
weights stay in one stacked `{experts, out, in}` tensor and the gather happens
inside the kernel, so no per-token copy of the weights is ever materialised.

Without it, an MoE block has to loop over experts and call `quantized_matmul`
once per expert. That scales with the expert count, which is 128 in Gemma 4 and
256 in the current Qwen MoE checkpoints — far past the point where a loop is
usable.

### What this adds

- `NIF(gather_qmm)` in `emlx_nif.cpp`, written against the existing
  `quantized_matmul` binding. Same parameters plus `lhs_indices`, `rhs_indices`
  and `sorted_indices`; registered at arity 13 through `ASYNC_NIF`.
- `EMLX.gather_qmm/11`, following the shape of `EMLX.quantized_matmul/8` —
  optional tensors unwrapped the same way, device merged across all six inputs,
  dispatched through the same command queue.
- `test/emlx/gather_qmm_test.exs`.

Nothing existing is touched: 96 added lines, no deletions.

### Correctness

Checked against `mx.gather_qmm` through the Python bindings on the same machine
and the same libmlx build: maximum absolute difference **6e-8** over 4 experts,
6 rows, 2 experts per row, 4-bit affine weights with group size 64.

The tests here cover it independently of Python:

- each row matches a plain `quantized_matmul` against the expert it names
- repeated indices produce identical rows
- `sorted_indices: true` and `false` agree
- output shape follows the index shape

The full suite passes: 2672 tests, 825 doctests.

### Notes

The shape protocol is the one `mlx_lm`'s `SwitchGLU` uses — input expanded to
`{..., 1, 1, in}`, indices `{..., experts_per_row}`, output
`{..., experts_per_row, 1, out}` — so an MoE layer built on this can follow the
reference implementation directly.

`EMLX.quantize/2` is rank-2 only, so stacked expert weights have to go through
`EMLX.quantize/4`. That is a separate matter and is left alone here.
