### PR TITLE
Materialise non-contiguous runtime_call arguments

### DIFF
--- a/emlx/c_src/emlx_runtime_call_bridge.hpp
+++ b/emlx/c_src/emlx_runtime_call_bridge.hpp
@@ -166,12 +166,9 @@ inline void invoke_runtime_call(int64_t callback_index,
           "emlx::native: failed to allocate binary for runtime_call arg");
     }
     if (nbytes > 0) {
-      // nbytes() is the logical size, but a non-contiguous array — anything
-      // broadcast, transposed or sliced — holds fewer elements than that in
-      // its buffer, so copying nbytes straight out of data() reads past the
-      // end and leaves the callback with only the first element intact.
-      // Materialise a row-major copy first, the same fallback to_blob_term
-      // uses.
+      // Non-contiguous arrays (broadcast/transposed/sliced) hold fewer
+      // bytes than nbytes() in their buffer; materialise a contiguous copy
+      // first, same as to_blob_term's fallback.
       if (in.flags().row_contiguous) {
         std::memcpy(bin.data, in.data<uint8_t>(), nbytes);
       } else {

--- a/emlx/c_src/emlx_runtime_call_bridge.hpp
+++ b/emlx/c_src/emlx_runtime_call_bridge.hpp
@@ -32,6 +32,8 @@
 #include "erl_nif.h"
 #include "mlx/allocator.h"
 #include "mlx/array.h"
+#include "mlx/ops.h"
+#include "mlx/transforms.h"
 #include "nx_nif_utils.hpp"
 
 #include <condition_variable>
@@ -164,7 +166,19 @@ inline void invoke_runtime_call(int64_t callback_index,
           "emlx::native: failed to allocate binary for runtime_call arg");
     }
     if (nbytes > 0) {
-      std::memcpy(bin.data, in.data<uint8_t>(), nbytes);
+      // nbytes() is the logical size, but a non-contiguous array — anything
+      // broadcast, transposed or sliced — holds fewer elements than that in
+      // its buffer, so copying nbytes straight out of data() reads past the
+      // end and leaves the callback with only the first element intact.
+      // Materialise a row-major copy first, the same fallback to_blob_term
+      // uses.
+      if (in.flags().row_contiguous) {
+        std::memcpy(bin.data, in.data<uint8_t>(), nbytes);
+      } else {
+        auto contiguous_in = mlx::core::contiguous(in);
+        mlx::core::eval(contiguous_in);
+        std::memcpy(bin.data, contiguous_in.data<uint8_t>(), nbytes);
+      }
     }
     arg_terms.push_back(enif_make_binary(msg_env, &bin));
   }

--- a/emlx/test/emlx/native/expr_test.exs
+++ b/emlx/test/emlx/native/expr_test.exs
@@ -4441,6 +4441,7 @@ defmodule EMLX.Native.ExprTest do
     Enum.zip(Nx.to_flat_list(a), Nx.to_flat_list(b))
     |> Enum.each(fn {av, bv} -> assert_in_delta(av, bv, tol) end)
   end
+
   describe "non-contiguous runtime_call arguments" do
     # nbytes() is the logical size, so copying that many bytes out of a
     # stride-0 array's buffer used to read past the end: the callback saw the

--- a/emlx/test/emlx/native/expr_test.exs
+++ b/emlx/test/emlx/native/expr_test.exs
@@ -4441,4 +4441,35 @@ defmodule EMLX.Native.ExprTest do
     Enum.zip(Nx.to_flat_list(a), Nx.to_flat_list(b))
     |> Enum.each(fn {av, bv} -> assert_in_delta(av, bv, tol) end)
   end
+  describe "non-contiguous runtime_call arguments" do
+    # nbytes() is the logical size, so copying that many bytes out of a
+    # stride-0 array's buffer used to read past the end: the callback saw the
+    # first element and zeros. Shapes were right and nothing raised, which made
+    # it silent and data-dependent.
+    defp echo(tensor) do
+      Nx.runtime_call(Nx.to_template(tensor), {tensor}, [], fn {t}, _opts -> t end)
+    end
+
+    test "a broadcast argument arrives whole" do
+      fun = Nx.Defn.compile(&echo/1, [Nx.template({4}, :f32)], compiler: EMLX)
+      assert_close(fun.(Nx.broadcast(2.5, {4})), Nx.broadcast(2.5, {4}))
+    end
+
+    test "a transposed argument arrives whole" do
+      dense = Nx.iota({2, 3}, type: :f32)
+      transposed = Nx.transpose(dense)
+
+      fun = Nx.Defn.compile(&echo/1, [Nx.to_template(transposed)], compiler: EMLX)
+      assert_close(fun.(transposed), transposed)
+    end
+
+    test "the callback sees every element, not just the first" do
+      sum = fn t ->
+        Nx.runtime_call(Nx.template({}, :f32), {t}, [], fn {inner}, _ -> Nx.sum(inner) end)
+      end
+
+      fun = Nx.Defn.compile(sum, [Nx.template({4}, :f32)], compiler: EMLX)
+      assert_close(fun.(Nx.broadcast(2.5, {4})), Nx.tensor(10.0))
+    end
+  end
 end


### PR DESCRIPTION
Fixes #134.

`emlx_runtime_call_bridge.hpp` sized each argument binary with `nbytes()` — the logical size — and then copied that many bytes straight out of `data()`. For a non-contiguous array that buffer holds fewer elements than the logical size, so the copy ran past its end: the callback saw the first element and whatever followed it, which read as zeros.

The fix mirrors what `to_blob_term` already does for the same reason: when the array is not row-contiguous, materialise a row-major copy and read from that.

Three regression tests in `expr_test.exs` cover a broadcast argument, a transposed argument, and a callback that reduces over every element. They fail without the bridge change and pass with it, and nothing else in the suite moves either way.

On the correction in the issue thread: agreed, and the plugin path is what the model this came from actually ends up using — `Nx.runtime_call` inside a compiled program cost about 7.5 ms per call against roughly 0.08 ms for the same kernel as a plugin node, so it was never viable as the hot path. The bug is worth fixing regardless, since `runtime_call` still corrupts data silently wherever it is used, and it is the first thing anyone reaches for before discovering the plugin pattern. Happy to send a docs note pointing at `EMLXAxon` from the `runtime_call` docs if that would help the next person find it sooner.
